### PR TITLE
camera_control_initialize() bug

### DIFF
--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -483,7 +483,10 @@ psmove_tracker_set_exposure(PSMoveTracker *tracker,
             break;
     }
 
-    camera_control_initialize();
+    #if defined(__APPLE__)
+        camera_control_initialize();
+    #endif
+
     tracker->exposure = psmove_tracker_adapt_to_light(tracker, target_luminance);
     camera_control_set_parameters(tracker->cc, 0, 0, 0, tracker->exposure,
             0, 0xffff, 0xffff, 0xffff, -1, -1);


### PR DESCRIPTION
Fixes https://github.com/thp/psmoveapi/pull/65... again

Camera_control_initialize() was called on all systems when it is
defined in camera_control_macosx.c only. This caused problems on Linux
and Windows.
