### PR TITLE
Check errors explicitly; don't rely on assert().

### DIFF
--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -477,18 +477,20 @@ psmove_calibration_load(PSMoveCalibration *calibration)
         return 0;
     }
 
-    rc = fread(calibration->usb_calibration,
-                    sizeof(calibration->usb_calibration),
-                    1, fp);
+    if (fread(calibration->usb_calibration,
+              sizeof(calibration->usb_calibration), 1, fp) != 1) {
+        psmove_CRITICAL("Unable to read USB calibration");
+        fclose(fp);
+        return 0;
+    }
+    if (fread(&(calibration->flags),
+              sizeof(calibration->flags), 1, fp) != 1) {
+        psmove_CRITICAL("Unable to read USB calibration");
+        fclose(fp);
+        return 0;
+    }
 
-    assert(rc == 1);
-
-    rc = fread(&(calibration->flags),
-                    sizeof(calibration->flags),
-                    1, fp);
-    assert(rc == 1);
     fclose(fp);
-
     return 1;
 }
 
@@ -501,20 +503,28 @@ psmove_calibration_save(PSMoveCalibration *calibration)
     size_t rc;
 
     fp = fopen(calibration->filename, "wb");
-    assert(fp != NULL);
+    if (fp == NULL) {
+        psmove_CRITICAL("Unable to write USB calibration");
+        return 0;
+    }
 
-    rc = fwrite(calibration->usb_calibration,
-                       sizeof(calibration->usb_calibration),
-                       1, fp);
-    assert(rc == 1);
+    if (fwrite(calibration->usb_calibration,
+               sizeof(calibration->usb_calibration),
+               1, fp) != 1) {
+        psmove_CRITICAL("Unable to write USB calibration");
+        fclose(fp);
+        return 0;
+    }
 
-    rc = fwrite(&(calibration->flags),
-                sizeof(calibration->flags),
-                1, fp);
-    assert(rc == 1);
+    if (fwrite(&(calibration->flags),
+               sizeof(calibration->flags),
+               1, fp) != 1) {
+        psmove_CRITICAL("Unable to write USB calibration");
+        fclose(fp);
+        return 0;
+    }
 
     fclose(fp);
-
     return 1;
 }
 


### PR DESCRIPTION
I decided to split them up by topic to make it simple and since your response time is so quick.

I think I got the indentation right this time ... 4-space indent, no tabs.

I went with "just past the open-paren" for multi-line function call indenting, but I'd be happy to change to whatever you prefer.

I tested to be sure that it compiled, but haven't tested at runtime (but I did test the previous version before the whitespace changes).
