### PR TITLE
Zero bluetooth host address in case we don't find one

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -987,6 +987,7 @@ psmove_pair(PSMove *move)
     }
     free(btaddr_string);
 #elif defined(__linux)
+    memset(btaddr, 0, sizeof(PSMove_Data_BTAddr));
     hci_for_each_dev(HCI_UP, _psmove_linux_bt_dev_info, (long)btaddr);
 #elif defined(_WIN32)
     HBLUETOOTH_RADIO_FIND hFind;


### PR DESCRIPTION
This is still not ideal, but at least we don't get uninitialized data that looks like a BT address.
