### PR TITLE
Fix inline function definition

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -156,7 +156,7 @@ typedef struct {
 #define TWELVE_BIT_SIGNED(x) (((x) & 0x800)?(-(((~(x)) & 0xFFF) + 1)):(x))
 
 /* Decode 16-bit signed value from data pointer and offset */
-inline int
+static inline int
 psmove_decode_16bit(char *data, int offset)
 {
     unsigned char low = data[offset] & 0xFF;


### PR DESCRIPTION
Compiling the library according to the C99 standard (which, for instance, is clang's default setting) would fail due to an undefined reference to "psmove_decode_16bit" when linking against libpsmoveapi. This fix makes sure that psmove_decode_16bit() is always resolved in the single translation unit that uses it, while keeping the "inline" hint.
