### PR TITLE
Update URL to psmove mailing list

### DIFF
--- a/README.ubuntu
+++ b/README.ubuntu
@@ -50,8 +50,7 @@ We assume that you are going to clone the repository into ~/src/psmoveapi/
 For questions, please read the archives of the PS Move Mailing List. If you
 cannot find an answer to your question in the archives, send an e-mail:
 
-   https://lists.ims.tuwien.ac.at/mailman/listinfo/psmove
+   https://groups.google.com/forum/#!aboutgroup/psmove
 
 
-Thomas Perl, 2012-09-27
 


### PR DESCRIPTION
The README for Ubuntu still mentions the obsolete address to the psmove mailing list while the rest of the documents already points to the correct location at Google Groups. This is fixed now.
