### PR TITLE
Don't call hid_exit within reinit when psmove_local_disabled.

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -481,7 +481,8 @@ psmove_reinit()
         clients = NULL;
     }
 
-    hid_exit();
+    if(!psmove_local_disabled)
+        hid_exit();
 }
 
 int


### PR DESCRIPTION
I believe I've pinned down some strange behaviour when reinitiating and disconnecting/reconnecting controllers when using moved on localhost.  This fixes those issues.  Regardless, we should not be calling hid_exit() during reinit if we are ignoring 'local' controllers.
