### PR TITLE
Pairing on OSX 10.10

### DIFF
--- a/src/platform/psmove_osxsupport.m
+++ b/src/platform/psmove_osxsupport.m
@@ -193,18 +193,21 @@ macosx_blued_register_psmove(char *addr)
         goto end;
     }
 
-    if (!macosx_bluetooth_set_powered(0)) {
-        OSXPAIR_DEBUG("Cannot shutdown Bluetooth (shut it down manually).\n");
-    }
+    if (minor_version < 10)
+    {
+        if (!macosx_bluetooth_set_powered(0)) {
+            OSXPAIR_DEBUG("Cannot shutdown Bluetooth (shut it down manually).\n");
+        }
 
-    int i = 0;
-    OSXPAIR_DEBUG("Waiting for blued shutdown (takes ca. 42s) ...\n");
-    while (macosx_blued_running()) {
-        usleep(1000000);
-        i++;
+        int i = 0;
+        OSXPAIR_DEBUG("Waiting for blued shutdown (takes ca. 42s) ...\n");
+        while (macosx_blued_running()) {
+            usleep(1000000);
+            i++;
+        }
+        OSXPAIR_DEBUG("blued successfully shutdown.\n");
     }
-    OSXPAIR_DEBUG("blued successfully shutdown.\n");
-
+    
     snprintf(cmd, sizeof(cmd), "osascript -e 'do shell script "
             "\"defaults write " OSX_BT_CONFIG_PATH
                 " HIDDevices -array-add \\\"%s\\\"\""
@@ -214,9 +217,12 @@ macosx_blued_register_psmove(char *addr)
         OSXPAIR_DEBUG("Could not run the command.");
     }
 
-    // FIXME: In OS X 10.7 this might not work - fork() and call set_powered(1)
-    // from a fresh process (e.g. like "blueutil 1") to switch Bluetooth on
-    macosx_bluetooth_set_powered(1);
+    if (minor_version < 10)
+    {
+        // FIXME: In OS X 10.7 this might not work - fork() and call set_powered(1)
+        // from a fresh process (e.g. like "blueutil 1") to switch Bluetooth on
+        macosx_bluetooth_set_powered(1);
+    }
 
     free(btaddr);
 


### PR DESCRIPTION
When pairing on OSX10.10 the pairing util previously stalled forever while waiting for blued to shutdown.  It seems the blued behavior on bluetooth start/stop is different on OSX10.10 compared to prior versions.   In 10.10, if you turn off bluetooth blued continues running, and also if you kill blued manually it is quickly replaced by the system (<1 sec).  So using 'is blued running?' is not a viable way of detecting if bluetooth has finished shutting down on OSX10.

Furthermore, it seems on OSX10.10 it is _not_ necessary to actually turn off bluetooth in order to pair a controller successfully.  So this change outright skips turning bluetooth off/on steps on OSX10.10 

It is worth mentioning that pairing on 10.10 suffers from a similar "must pair controller twice" issue as is encountered on 10.7  This behavior is the same whether bluetooth is stopped or left running.
