### PR TITLE
Fix BlueZ 5 status on non-Linux platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ endif()
 
 set(INFO_USE_CL_EYE_SDK "No (Windows only)")
 set(INFO_USE_PS3EYE_DRIVER "No (OS X only)")
+set(INFO_BLUEZ5_SUPPORT "No")
 
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_library(FOUNDATION Foundation)


### PR DESCRIPTION
The info whether BlueZ 5 was detected on the system was displayed on all platforms but only properly initialized on Linux. This fix adds a proper default values for all platforms.
