### PR TITLE
ignoring build directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 include/psmove_config.h
+build*


### PR DESCRIPTION
i ignore `build*` (not `build/*` or `build`) on purpose:

`build*` will ignore `build`, but also `build32` and `build64`, and even `build-bananas`. The last one is not really important, but i use the two in the middle in my build script.