### PR TITLE
Ps3eye fixes in Windows and OSX.

### DIFF
--- a/examples/c/test_tracker.c
+++ b/examples/c/test_tracker.c
@@ -56,6 +56,11 @@ int main(int arg, char** args) {
 
     fprintf(stderr, "Trying to init PSMoveTracker...");
     PSMoveTracker* tracker = psmove_tracker_new();
+    if (!tracker)
+    {
+        fprintf(stderr, "Could not init PSMoveTracker.\n");
+        return 1;
+    }
     psmove_tracker_set_mirror(tracker, PSMove_True);
     fprintf(stderr, "OK\n");
 

--- a/src/tracker/platform/camera_control_macosx.c
+++ b/src/tracker/platform/camera_control_macosx.c
@@ -27,7 +27,7 @@
  **/
 
 #include "../camera_control.h"
-
+#include "../camera_control_private.h"
 #include "psmove_osxsupport.h"
 
 void
@@ -44,8 +44,23 @@ camera_control_set_parameters(CameraControl* cc,
         int contrast, int brightness)
 {
 #if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
-    // TODO: Implement setting those parameters on cc->eye
-    psmove_WARNING("Unimplemented: Setting of PS3EYEDriver parameters\n");
+    //autoE... setAutoExposure not defined in ps3eye.h
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN, autoG > 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE, autoWB > 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE, round((511 * exposure) / 0xFFFF));
+    ps3eye_set_parameter(cc->eye, PS3EYE_GAIN, round((79 * gain) / 0xFFFF));
+    //ps3eye_set_parameter(cc->eye, PS3EYE_REDBALANCE, round((255 * wbRed) / 0xFFFF));
+    //wbGreen... setGreenBalance not defined in ps3eye.h
+    //ps3eye_set_parameter(cc->eye, PS3EYE_BLUEBALANCE, round((255 * wbBlue) / 0xFFFF));
+    //ps3eye_set_parameter(cc->eye, PS3EYE_CONTRAST, contrast);  // Transform unknown.
+    //ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS, brightness);  // Transform unknown.
+
+    /** The following parameters could be set but are not passed into this function:
+     * ps3eye_set_parameter(cc->eye, PS3EYE_SHARPNESS, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_HUE, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_VFLIP, ??);
+     **/
 #else
     macosx_camera_set_exposure_lock(1);
 #endif

--- a/src/tracker/platform/camera_control_win32.c
+++ b/src/tracker/platform/camera_control_win32.c
@@ -181,6 +181,24 @@ void camera_control_set_parameters(CameraControl* cc, int autoE, int autoG, int 
             cvReleaseCapture(&cc->capture);
         }
 
+    //autoE... setAutoExposure not defined in ps3eye.h
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN, autoG > 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE, autoWB > 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE, round((511 * exposure) / 0xFFFF));
+    ps3eye_set_parameter(cc->eye, PS3EYE_GAIN, round((79 * gain) / 0xFFFF));
+    //ps3eye_set_parameter(cc->eye, PS3EYE_REDBALANCE, round((255 * wbRed) / 0xFFFF));
+    //wbGreen... setGreenBalance not defined in ps3eye.h
+    //ps3eye_set_parameter(cc->eye, PS3EYE_BLUEBALANCE, round((255 * wbBlue) / 0xFFFF));
+    //ps3eye_set_parameter(cc->eye, PS3EYE_CONTRAST, contrast);  // Transform unknown.
+    //ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS, brightness);  // Transform unknown.
+
+    /** The following parameters could be set but are not passed into this function:
+     * ps3eye_set_parameter(cc->eye, PS3EYE_SHARPNESS, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_HUE, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, ??);
+     * ps3eye_set_parameter(cc->eye, PS3EYE_VFLIP, ??);
+     **/
+
 	int width, height;
 	get_metrics(&width, &height);
 

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -563,11 +563,17 @@ psmove_tracker_new_with_camera(int camera) {
 #endif
 
 	// start the video capture device for tracking
-	tracker->cc = camera_control_new(camera);
+    tracker->cc = camera_control_new(camera); // Returns NULL if no control found.
+                                              // e.g. PS3EYE set during compile but not plugged in.
+    if (!tracker->cc)
+    {
+        free(tracker);
+        return NULL;
+    }
 
         char *intrinsics_xml = psmove_util_get_file_path(INTRINSICS_XML);
         char *distortion_xml = psmove_util_get_file_path(DISTORTION_XML);
-	camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml);
+        camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml); // Crashes if cc is NULL
         free(intrinsics_xml);
         free(distortion_xml);
 

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -573,7 +573,7 @@ psmove_tracker_new_with_camera(int camera) {
 
         char *intrinsics_xml = psmove_util_get_file_path(INTRINSICS_XML);
         char *distortion_xml = psmove_util_get_file_path(DISTORTION_XML);
-        camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml); // Crashes if cc is NULL
+        camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml);
         free(intrinsics_xml);
         free(distortion_xml);
 


### PR DESCRIPTION
This replaces PR #152 

-tracker fails gracefully when PS3EYE specified at compile time but not plugged in.
-exposure and gain parameters passed through to PS3EYE when using PS3EYEDriver. This greatly improves the performance of the tracker in well-lit environments.