### PR TITLE
Fix wiki links to point to new location

### DIFF
--- a/examples/c/test_extension.c
+++ b/examples/c/test_extension.c
@@ -48,7 +48,7 @@ void handle_sharp_shooter(PSMove_Ext_Data *data, unsigned int move_buttons)
 {
     /**
      * For a detailed device documentation and a guide for accessing button values, see
-     * https://code.google.com/p/moveonpc/wiki/SharpShooter
+     * https://github.com/nitsch/moveonpc/wiki/Sharp-Shooter
      **/
 
     assert(data != NULL);
@@ -83,7 +83,7 @@ void handle_racing_wheel(PSMove *move, PSMove_Ext_Data *data, unsigned int move_
 {
     /**
      * For a detailed device documentation and a guide for accessing button values, see
-     * https://code.google.com/p/moveonpc/wiki/RacingWheel
+     * https://github.com/nitsch/moveonpc/wiki/Racing-Wheel
      **/
 
     assert(data != NULL);

--- a/include/psmove.h
+++ b/include/psmove.h
@@ -82,7 +82,7 @@ enum PSMove_Button {
      * laid out in the input report.
      *
      * Source:
-     * https://code.google.com/p/moveonpc/wiki/InputReport
+     * https://github.com/nitsch/moveonpc/wiki/Input-report
      **/
     Btn_TRIANGLE = 1 << 4, /*!< Green triangle */
     Btn_CIRCLE = 1 << 5, /*!< Red circle */

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -1425,7 +1425,7 @@ psmove_get_buttons(PSMove *move)
      * See also: enum PSMove_Button in include/psmove.h
      *
      * Source:
-     * https://code.google.com/p/moveonpc/wiki/InputReport
+     * https://github.com/nitsch/moveonpc/wiki/Input-report
      *
      *           21  1    1  00000   0 <- bit (read top to bottom)
      *   ........09..6....1..87654...0

--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -126,7 +126,7 @@ psmove_calibration_parse_usb(PSMoveCalibration *calibration)
 
     printf("\n");
 
-    /* http://code.google.com/p/moveonpc/wiki/CalibrationData */
+    /* https://github.com/nitsch/moveonpc/wiki/Calibration-data */
 
     for (orientation=0; orientation<6; orientation++) {
         x = psmove_calibration_decode(data, 0x04 + 6*orientation);


### PR DESCRIPTION
Since Google Code will shut down, I decided to transfer the documentation I maintained as part of the moveonpc project to GitHub. The wiki can now be found at:

https://github.com/nitsch/moveonpc/wiki