### PR TITLE
Fix Windows include filenames

### DIFF
--- a/src/platform/psmove_winsupport.c
+++ b/src/platform/psmove_winsupport.c
@@ -29,7 +29,7 @@
 #include "../psmove_private.h"
 #include "psmove_winsupport.h"
 
-#include <BluetoothAPIs.h>
+#include <bluetoothapis.h>
 
 #include <malloc.h>
 #include <stdio.h>

--- a/src/platform/psmove_winsupport.h
+++ b/src/platform/psmove_winsupport.h
@@ -29,7 +29,7 @@
 #ifndef PSMOVE_WINSUPPORT_H
 #define PSMOVE_WINSUPPORT_H
 
-#include <Windows.h>
+#include <windows.h>
 
 
 /**


### PR DESCRIPTION
MinGW contains Windows headers files with lower-case filenames only. When cross-compiling on Linux, some of these would not be found due to case-sensitivity. This fix converts the names to lower case in the #include directives.