### PR TITLE
CMake options for custom local OPENCV_SRC_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ option(PSMOVE_BUILD_OPENGL_EXAMPLES "Build the OpenGL examples" OFF)
 option(PSMOVE_BUILD_TESTS "Build the C tests" ON)
 option(PSMOVE_BUILD_TUIO_SERVER "Build the TUIO server" OFF)
 
+# Use a custom location for OpenCV src dir
+option(OPENCV_SRC_DIR "Path to local OpenCV" ${CMAKE_CURRENT_SOURCE_DIR}/opencv)
+
+# allow for an in-source build of local OpenCV
+option(PSMOVE_OPENCV_BUILT_IN_SOURCE "Local OpenCV was built in its source tree" OFF)
 
 # Enable tweaks (e.g. registry settings on Windows, ...) for PS Eye
 option(PSMOVE_USE_PSEYE "Enable tweaks for the PS Eye camera" ON)
@@ -133,6 +138,13 @@ option(PSMOVE_USE_LOCAL_OPENCV "Use locally-built OpenCV (static linking)" OFF)
 if (PSMOVE_USE_LOCAL_OPENCV)
     # Force tracker build with a locally-built opencv library installation
 
+    # allow for an in-source build of OpenCV
+    if (PSMOVE_OPENCV_BUILT_IN_SOURCE)
+        set(OPENCV_BUILD_DIR ${OPENCV_SRC_DIR})
+    else ()
+        set(OPENCV_BUILD_DIR ${OPENCV_SRC_DIR}/build)
+    endif()
+
     link_directories(${OPENCV_SRC_DIR}/build/lib)
     link_directories(${OPENCV_SRC_DIR}/build/3rdparty/lib)
 
@@ -141,7 +153,7 @@ if (PSMOVE_USE_LOCAL_OPENCV)
       
       # install the required OpenCV headers
       install(DIRECTORY ${OPENCV_SRC_DIR}/modules/${OPENCV_MODULE}/include/opencv2 DESTINATION include)
-    endforeach()    
+    endforeach()
 
     set(PSMOVE_BUILD_TRACKER ON)
     set(INFO_BUILD_TRACKER "Yes (with local OpenCV)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ option(PSMOVE_BUILD_TESTS "Build the C tests" ON)
 option(PSMOVE_BUILD_TUIO_SERVER "Build the TUIO server" OFF)
 
 # Use a custom location for OpenCV src dir
-option(OPENCV_SRC_DIR "Path to local OpenCV" ${CMAKE_CURRENT_SOURCE_DIR}/opencv)
+set(OPENCV_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/opencv CACHE STRING "Path to local OpenCV source tree")
 
 # allow for an in-source build of local OpenCV
 option(PSMOVE_OPENCV_BUILT_IN_SOURCE "Local OpenCV was built in its source tree" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ endif()
 option(PSMOVE_USE_LOCAL_OPENCV "Use locally-built OpenCV (static linking)" OFF)
 if (PSMOVE_USE_LOCAL_OPENCV)
     # Force tracker build with a locally-built opencv library installation
-    set(OPENCV_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/opencv)
+
     link_directories(${OPENCV_SRC_DIR}/build/lib)
     link_directories(${OPENCV_SRC_DIR}/build/3rdparty/lib)
 
@@ -141,8 +141,8 @@ if (PSMOVE_USE_LOCAL_OPENCV)
       
       # install the required OpenCV headers
       install(DIRECTORY ${OPENCV_SRC_DIR}/modules/${OPENCV_MODULE}/include/opencv2 DESTINATION include)
-    endforeach() 
-    
+    endforeach()    
+
     set(PSMOVE_BUILD_TRACKER ON)
     set(INFO_BUILD_TRACKER "Yes (with local OpenCV)")
 

--- a/contrib/cross-compile-mingw64
+++ b/contrib/cross-compile-mingw64
@@ -1,4 +1,4 @@
-#!/bin/bash -x -e
+#!/bin/bash -xe
 #
 # Script to cross compile PS Move API for Windows on a Linux host
 # Thomas Perl <m@thp.io>; 2012-09-27


### PR DESCRIPTION
These are a couple of changes we needed to more easily use PSMoveAPI as an external project with CMake.

The OpenCV changes should not affect any existing builds - they allow a caller to specify `OPENCV_SRC_DIR` to have the PSMoveAPI CMakeLists.txt look elsewhere for OpenCV. You can also specify is OpenCV was built using an in-source build using `OPENCV_BUILT_IN_SOURCE`.