### PR TITLE
Make Bluetooth pairing/connecting work in Windows 8

### DIFF
--- a/docs/README.win32_mingw64
+++ b/docs/README.win32_mingw64
@@ -162,8 +162,9 @@ IMPORTANT: Get the right MinGW version!
 	to store the host's Bluetooth device address in the Move and register the
 	controller. Follow the instructions on the screen until the Move's red
 	status LED eventually remains lit to indicate a working Bluetooth
-	connection. Since this step involves modifications of the Windows registry,
-	you will probably have to run psmovepair.exe as Administrator.
+	connection. Since this step involves modifications of the registry on
+	Windows 8 and later, you will probably have to run psmovepair.exe as
+	Administrator.
 
 	Note that the pairing step is necessary only once per controller. From that
 	point on you can enable the Bluetooth connection simply by pressing the

--- a/docs/README.win32_mingw64
+++ b/docs/README.win32_mingw64
@@ -162,7 +162,8 @@ IMPORTANT: Get the right MinGW version!
 	to store the host's Bluetooth device address in the Move and register the
 	controller. Follow the instructions on the screen until the Move's red
 	status LED eventually remains lit to indicate a working Bluetooth
-	connection.
+	connection. Since this step involves modifications of the Windows registry,
+	you will probably have to run psmovepair.exe as Administrator.
 
 	Note that the pairing step is necessary only once per controller. From that
 	point on you can enable the Bluetooth connection simply by pressing the

--- a/src/platform/psmove_winsupport.c
+++ b/src/platform/psmove_winsupport.c
@@ -337,12 +337,6 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
         return 1;
     }
 
-    /* Keep track of the number of times the loop iterates so we may timeout. */
-    int timeout_duration = 30;  // seconds
-    int sleep_interval = 1000; // msec
-    int timeout_iterations = timeout_duration * 1000 / sleep_interval;
-    int loop_count = 0;
-    
     printf("\n" \
            "    Unplug the controller.\n" \
            "\n"
@@ -393,16 +387,9 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
                 WINPAIR_DEBUG("Bluetooth device matching the given address is not a Move Motion Controller");
             }
         }
-        if (loop_count >= timeout_iterations) {
-            printf("\n"
-                   "    A connection could not be established. This is not\n"
-                   "    unusual in Windows. Please refer to the README document\n"
-                   "    for your platform for more information. Press Ctrl+C to cancel.");
-        }
 
         /* sleep for 1 second */
         Sleep(1000);
-        loop_count++;
     }
 
     free(move_addr);

--- a/src/platform/psmove_winsupport.c
+++ b/src/platform/psmove_winsupport.c
@@ -377,7 +377,8 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
            "    remains lit. Press Ctrl+C to cancel anytime.\n");
 
     unsigned int scan = 0;
-    while (1) {
+    int connected = 0;
+    while (!connected) {
         BLUETOOTH_DEVICE_INFO device_info;
         if (get_bluetooth_device_info(hRadio, move_addr, &device_info, scan == 0) != 0) {
             WINPAIR_DEBUG("No Bluetooth device found matching the given address");
@@ -425,6 +426,7 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
                         if (is_connection_established(hRadio, &device_info)) {
                             /* if we have a connection, stop trying to connect this device */
                             printf("Connection verified.\n");
+                            connected = 1;
                             break;
                         }
                     }

--- a/src/platform/psmove_winsupport.h
+++ b/src/platform/psmove_winsupport.h
@@ -30,18 +30,20 @@
 #define PSMOVE_WINSUPPORT_H
 
 #include <windows.h>
+#include <bluetoothapis.h>
 
 
 /**
  * \brief Interactively establish a Bluetooth connection between Move and a host radio
  *
  * \param move_addr The Move's Bluetooth device address in the format \c "aa:bb:cc:dd:ee:ff"
+ * \param radio_addr The host radio's Bluetooth device address
  * \param hRadio A valid handle to the host Bluetooth radio
  *
  * \return Zero on success, or a non-zero value upon error
  **/
 int
-windows_register_psmove(const char *move_addr, const HANDLE hRadio);
+windows_register_psmove(const char *move_addr, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio);
 
 /**
  * \brief Get a handle to the first local Bluetooth radio found

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -1135,7 +1135,7 @@ psmove_pair(PSMove *move)
 #endif
 
 #if defined(_WIN32)
-    windows_register_psmove(addr, hRadio);
+    windows_register_psmove(addr, &radioInfo.address, hRadio);
     CloseHandle(hRadio);
 #endif
 


### PR DESCRIPTION
This adds setting the device's "VirtuallyCabled" property in the registry to the psmovepair utility. @betonme @cboulay  and other Windows 8 users: please test!