### PR TITLE
Fix unidentified issue

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -914,7 +914,7 @@ _psmove_read_btaddrs(PSMove *move, PSMove_Data_BTAddr *host, PSMove_Data_BTAddr 
         res = hid_get_feature_report(move->handle, btg, sizeof(btg));
     }
 
-    if (res == sizeof(btg)) {
+    if (res == sizeof(btg) || res == sizeof(btg) + 1) {
         if (controller != NULL) {
             memcpy(*controller, btg+1, 6);
         }


### PR DESCRIPTION
I tried the library on a new machine, found two issues with it, and fixed them (this is one of them).  I'm still not sure what the ramifications of the changes are, but they work on the target machine.  The only difference I can identify is that a newer version of Windows 10 has been installed on the new machine.

... to try to clarify. It seems that the version of 'hid_get_feature_report' I was calling added an extra byte as a report ID. This extra byte made the result 1 byte longer than was expected. I'm guessing this isn't a widespread problem, or the previous code wouldn't have worked, so I've added my case as an alternative condition. I don't fully understand the ramifications of this change, but it works in my case.

For the record, the second issue I mentioned doesn't appear to be immediately fixable on this end, as it is contained within in HIDAPI.