### PR TITLE
Add -lrt to build flags for psmoveapi_static.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,8 @@ list(APPEND PSMOVEAPI_INSTALL_TARGETS psmoveapi)
 
 add_library(psmoveapi_static STATIC ${PSMOVEAPI_LIBRARY_SRC})
 target_link_libraries(psmoveapi_static ${PSMOVEAPI_REQUIRED_LIBS})
+target_link_libraries(psmoveapi_static rt)
+
 set_target_properties(psmoveapi_static PROPERTIES
     COMPILE_FLAGS -DBUILDING_STATIC_LIBRARY)
 


### PR DESCRIPTION
I found this necessary to build on Raspbian. There may be a better way of doing this; I'm not very familiar with CMake. Tested with 'example' on Raspbian (armv6l) and Ubuntu 14.04 (x86_64).