### PR TITLE
Windows fixes

### DIFF
--- a/examples/c/psmove_examples_opengl.h
+++ b/examples/c/psmove_examples_opengl.h
@@ -4,6 +4,7 @@
 #ifdef __APPLE__
     #include <OpenGL/gl.h>
     #include <GLUT/glut.h>
+	#include <SDL.h>
 #elif _WIN32
 	#ifndef WIN32_LEAN_AND_MEAN
 	#define WIN32_LEAN_AND_MEAN
@@ -13,9 +14,11 @@
 
 	#include <GL/gl.h>
 	#include <GL/glu.h>
+	#include <SDL.h>
 #else
     #include <GL/gl.h>
     #include <GL/glut.h>
+	#include <SDL2/SDL.h>
 #endif
 
 #ifdef _WIN32
@@ -26,8 +29,6 @@
 	#pragma warning (disable:4244)	/* Disable bogus conversion warnings. */
 	#pragma warning (disable:4305)  /* VC++ 5.0 version of above warning. */
 #endif
-
-#include <SDL2/SDL.h>
 
 static GLUquadricObj *g_quadObj;
 

--- a/src/tracker/camera_control.c
+++ b/src/tracker/camera_control.c
@@ -238,11 +238,8 @@ camera_control_read_calibration(CameraControl* cc,
                     camera_control_query_frame(cc, NULL, NULL));
         }
 
-        int width, height;
-        get_metrics(&width, &height);
-
-        cc->mapx = cvCreateImage(cvSize(width, height), IPL_DEPTH_32F, 1);
-        cc->mapy = cvCreateImage(cvSize(width, height), IPL_DEPTH_32F, 1);
+		cc->mapx = cvCreateImage(cvSize(cc->width, cc->height), IPL_DEPTH_32F, 1);
+		cc->mapy = cvCreateImage(cvSize(cc->width, cc->height), IPL_DEPTH_32F, 1);
 
         cvInitUndistortMap(intrinsic, distortion, cc->mapx, cc->mapy);
 


### PR DESCRIPTION
Fixed Window build issue with latest version of PSMoveAPI and fixed crash when using the camera in non-640x480 mode.