### PR TITLE
OpenCV 3.1 + MingW build fix

### DIFF
--- a/contrib/build_scripts/msvc/build_msvc_common.bat
+++ b/contrib/build_scripts/msvc/build_msvc_common.bat
@@ -112,7 +112,7 @@ IF %ERRORLEVEL% NEQ 0 (
 REM Clone OpenCV
 IF NOT EXIST %OPENCV_DIR% (
 	cd %PSMOVE_API_EXTERNAL_DIR%
-	git clone --depth 1 --branch 2.4.11 git://github.com/Itseez/opencv.git
+	git clone --depth 1 --branch 3.1.0 git://github.com/Itseez/opencv.git
 ) ELSE (
 	echo.
 	echo OpenCV dir already exists; assuming it has been cloned already
@@ -128,14 +128,14 @@ IF NOT EXIST build mkdir build
 cd build
 
 IF "%MSVC_VERSION%"=="2015" (
-	cmake .. -G "Visual Studio 14 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF
+	cmake .. -G "Visual Studio 14 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=ON -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF
 	IF !ERRORLEVEL! NEQ 0 (
 		echo Failed to generate OpenCV solution
 		goto Error
 	)	
 ) ELSE (
 	IF "%MSVC_VERSION%" == "2013" (
-		cmake .. -G "Visual Studio 12 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF
+		cmake .. -G "Visual Studio 12 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=ON -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF
 		IF !ERRORLEVEL! NEQ 0 ( 
 			echo Failed to generate OpenCV solution
 			goto Error

--- a/contrib/build_scripts/osx/build-osx-snapshot
+++ b/contrib/build_scripts/osx/build-osx-snapshot
@@ -56,7 +56,7 @@ cd $PSMOVEAPI_CHECKOUT
 if [ ! -d $OPENCV_INSTALL_DIR ]; then
     cd external
     if [ ! -d opencv ]; then
-        git clone git://github.com/Itseez/opencv.git
+		git clone --depth 1 --branch 3.1.0 git://github.com/Itseez/opencv.git
     fi
     cd opencv
     rm -rf build

--- a/docs/README.win64_msvc
+++ b/docs/README.win64_msvc
@@ -53,12 +53,12 @@ Manual build
 2. OpenCV (Optional -- only needed to build the positional tracker)
 
    In `psmoveapi/external`
-   git clone --depth 1 --branch 2.4.11 git://github.com/Itseez/opencv.git
+   git clone --depth 1 --branch 3.1.0 git://github.com/Itseez/opencv.git
    `cd opencv`
    `mkdir build`
    `cd build`
-   VS2013: `cmake .. -G "Visual Studio 12 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF`
-   VS2015: `cmake .. -G "Visual Studio 14 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF`
+   VS2013: `cmake .. -G "Visual Studio 12 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=ON -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF`
+   VS2015: `cmake .. -G "Visual Studio 14 Win64" -DBUILD_SHARED_LIBS=0 -DBUILD_WITH_STATIC_CRT=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DBUILD_DOCS=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_flann=ON -DBUILD_opencv_features2d=ON -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_ml=ON -DBUILD_opencv_video=OFF -DBUILD_opencv_java=OFF -DWITH_OPENEXR=OFF -DWITH_FFMPEG=OFF -DWITH_JASPER=OFF -DWITH_TIFF=OFF`
    
    Open the solution in psmoveapi\external\opencv\build\OpenCV.sln
    Change the target to Release or Debug (as desired) at the top of the Visual Studio window

--- a/external/msvc-support/unistd.h
+++ b/external/msvc-support/unistd.h
@@ -54,6 +54,15 @@ typedef unsigned __int64  uint64_t;
 	#define snprintf _snprintf  // Not exactly the same, but close enough.
 #endif
 
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
 int usleep(__int64 useconds);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* unistd.h  */

--- a/src/math/psmove_math.h
+++ b/src/math/psmove_math.h
@@ -47,12 +47,6 @@
 #define k_real_half_pi 0.5f*k_real_pi
 
 //-- macros ----
-#ifdef isfinite
-#define is_valid_float(x) (!isnan(x) && isfinite(x))
-#else
-#define is_valid_float(x) (!isnan(x))
-#endif
-
 #define is_nearly_equal(a, b, epsilon) (fabsf(a-b) <= epsilon)
 #define is_nearly_zero(x) is_nearly_equal(x, 0.0f, k_real_epsilon)
 
@@ -64,12 +58,6 @@
 
 #ifndef sqr
 #define sqr(x) (x*x)
-#endif
-
-#ifdef NDEBUG
-#define assert_valid_float(x) assert(is_valid_float(x))
-#else
-#define assert_valid_float(x)     ((void)0)
 #endif
 
 //-- inline -----

--- a/src/math/psmove_quaternion.cpp
+++ b/src/math/psmove_quaternion.cpp
@@ -31,6 +31,19 @@
 
 #include <assert.h>
 
+//-- macros ----
+#ifdef isfinite
+#define is_valid_float(x) (!std::isnan(x) && isfinite(x))
+#else
+#define is_valid_float(x) (!std::isnan(x))
+#endif
+
+#ifdef NDEBUG
+#define assert_valid_float(x) assert(is_valid_float(x))
+#else
+#define assert_valid_float(x)     ((void)0)
+#endif
+
 //-- globals ----
 const glm::quat g_psmove_quaternion_zero = glm::quat(0, 0, 0, 0);
 const glm::quat *k_psmove_quaternion_zero = &g_psmove_quaternion_zero;

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -176,6 +176,15 @@ source_group("Source Files\\iniparser" FILES ${INIPARSER_SRC})
 
 
 if(PSMOVE_BUILD_TRACKER)
+	IF(MSVC)
+		# Due to a bug in OpenCV 3.0+, C source files that call cvGetSize will crash when built by MSVC.
+		# psmove_tracker.c is such a file, so we need to force the C++ compiler to be used for it, even though it's a C file. 
+		# Once the OpenCV bug is fixed, this can/should be removed.
+		#
+		# See https://github.com/Itseez/opencv/issues/6221 for more info.
+		set_source_files_properties( ${CMAKE_CURRENT_LIST_DIR}/psmove_tracker.c PROPERTIES LANGUAGE CXX )
+	ENDIF(MSVC)
+	
     include_directories(${ROOT_DIR}/external/glm)
     add_library(psmoveapi_tracker SHARED
         ${PSMOVEAPI_TRACKER_SRC}

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -62,53 +62,6 @@
 #define PSEYE_BACKUP_FILE "PSEye_backup.ini"
 #define COLOR_MAPPING_DAT "colormapping.dat"
 
-/**
- * Helper function to create the default tracker settings. Needed so this file can be compiled as both C and C++ (C++ does not support designated initializers)
-**/
-static const PSMoveTrackerSettings create_tracker_default_settings()
-{
-	PSMoveTrackerSettings defaults;
-
-	defaults.camera_frame_width = 0;
-    defaults.camera_frame_height = 0;
-    defaults.camera_frame_rate = 0;
-    defaults.camera_auto_gain = PSMove_False;
-    defaults.camera_gain = 0;
-    defaults.camera_auto_white_balance = PSMove_False;
-    defaults.camera_exposure = (255 * 15) / 0xFFFF;
-    defaults.camera_brightness = 0;
-    defaults.camera_mirror = PSMove_False;
-    defaults.exposure_mode = Exposure_LOW;
-    defaults.calibration_blink_delay = 200;
-    defaults.calibration_diff_t = 20;
-    defaults.calibration_min_size = 50;
-    defaults.calibration_max_distance = 30;
-    defaults.calibration_size_std = 10;
-    defaults.color_mapping_max_age = 2 * 60 * 60;
-    defaults.dimming_factor = 1.f;
-    defaults.color_hue_filter_range = 20;
-    defaults.color_saturation_filter_range = 85;
-    defaults.color_value_filter_range = 85;
-    defaults.tracker_adaptive_xy = 1;
-    defaults.tracker_adaptive_z = 1;
-    defaults.color_adaption_quality_t = 35.f;
-    defaults.color_update_rate = 1.f;
-    defaults.search_tile_width = 0;
-    defaults.search_tile_height = 0;
-    defaults.search_tiles_horizontal = 0;
-    defaults.search_tiles_count = 0;
-    defaults.roi_adjust_fps_t = 160;
-    defaults.tracker_quality_t1 = 0.3f;
-    defaults.tracker_quality_t2 = 0.7f;
-    defaults.tracker_quality_t3 = 4.7f;
-    defaults.color_update_quality_t1 = 0.8f;
-    defaults.color_update_quality_t2 = 0.2f;
-    defaults.color_update_quality_t3 = 6.f;
-	defaults.intrinsics_xml = "intrinsics.xml";
-	defaults.distortion_xml = "distortion.xml";
-
-	return defaults;
-}
 
 /**
  * Syntactic sugar - iterate over all valid controllers of a tracker
@@ -390,7 +343,43 @@ psmove_tracker_remember_color(PSMoveTracker *tracker, struct PSMove_RGBValue rgb
 void
 psmove_tracker_settings_set_default(PSMoveTrackerSettings *settings)
 {
-    *settings = create_tracker_default_settings(); 
+    settings->camera_frame_width = 0;
+    settings->camera_frame_height = 0;
+    settings->camera_frame_rate = 0;
+    settings->camera_auto_gain = PSMove_False;
+    settings->camera_gain = 0;
+    settings->camera_auto_white_balance = PSMove_False;
+    settings->camera_exposure = (255 * 15) / 0xFFFF;
+    settings->camera_brightness = 0;
+    settings->camera_mirror = PSMove_False;
+    settings->exposure_mode = Exposure_LOW;
+    settings->calibration_blink_delay = 200;
+    settings->calibration_diff_t = 20;
+    settings->calibration_min_size = 50;
+    settings->calibration_max_distance = 30;
+    settings->calibration_size_std = 10;
+    settings->color_mapping_max_age = 2 * 60 * 60;
+    settings->dimming_factor = 1.f;
+    settings->color_hue_filter_range = 20;
+    settings->color_saturation_filter_range = 85;
+    settings->color_value_filter_range = 85;
+    settings->tracker_adaptive_xy = 1;
+    settings->tracker_adaptive_z = 1;
+    settings->color_adaption_quality_t = 35.f;
+    settings->color_update_rate = 1.f;
+    settings->search_tile_width = 0;
+    settings->search_tile_height = 0;
+    settings->search_tiles_horizontal = 0;
+    settings->search_tiles_count = 0;
+    settings->roi_adjust_fps_t = 160;
+    settings->tracker_quality_t1 = 0.3f;
+    settings->tracker_quality_t2 = 0.7f;
+    settings->tracker_quality_t3 = 4.7f;
+    settings->color_update_quality_t1 = 0.8f;
+    settings->color_update_quality_t2 = 0.2f;
+    settings->color_update_quality_t3 = 6.f;
+    settings->intrinsics_xml = "intrinsics.xml";
+    settings->distortion_xml = "distortion.xml";
 }
 
 PSMoveTracker *psmove_tracker_new() {

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -62,45 +62,55 @@
 #define PSEYE_BACKUP_FILE "PSEye_backup.ini"
 #define COLOR_MAPPING_DAT "colormapping.dat"
 
-static const PSMoveTrackerSettings tracker_default_settings = {
-    .camera_frame_width = 0,
-    .camera_frame_height = 0,
-    .camera_frame_rate = 0,
-    .camera_auto_gain = PSMove_False,
-    .camera_gain = 0,
-    .camera_auto_white_balance = PSMove_False,
-    .camera_exposure = (255 * 15) / 0xFFFF,
-    .camera_brightness = 0,
-    .camera_mirror = PSMove_False,
-    .exposure_mode = Exposure_LOW,
-    .calibration_blink_delay = 200,
-    .calibration_diff_t = 20,
-    .calibration_min_size = 50,
-    .calibration_max_distance = 30,
-    .calibration_size_std = 10,
-    .color_mapping_max_age = 2 * 60 * 60,
-    .dimming_factor = 1.f,
-    .color_hue_filter_range = 20,
-    .color_saturation_filter_range = 85,
-    .color_value_filter_range = 85,
-    .tracker_adaptive_xy = 1,
-    .tracker_adaptive_z = 1,
-    .color_adaption_quality_t = 35.f,
-    .color_update_rate = 1.f,
-    .search_tile_width = 0,
-    .search_tile_height = 0,
-    .search_tiles_horizontal = 0,
-    .search_tiles_count = 0,
-    .roi_adjust_fps_t = 160,
-    .tracker_quality_t1 = 0.3f,
-    .tracker_quality_t2 = 0.7f,
-    .tracker_quality_t3 = 4.7f,
-    .color_update_quality_t1 = 0.8f,
-    .color_update_quality_t2 = 0.2f,
-    .color_update_quality_t3 = 6.f,
-	.intrinsics_xml = "intrinsics.xml",
-	.distortion_xml = "distortion.xml"
-};
+/**
+ * Helper function to create the default tracker settings. Needed so this file can be compiled as both C and C++ (C++ does not support designated initializers)
+**/
+static const PSMoveTrackerSettings create_tracker_default_settings()
+{
+	PSMoveTrackerSettings defaults;
+
+	defaults.camera_frame_width = 0;
+    defaults.camera_frame_height = 0;
+    defaults.camera_frame_rate = 0;
+    defaults.camera_auto_gain = PSMove_False;
+    defaults.camera_gain = 0;
+    defaults.camera_auto_white_balance = PSMove_False;
+    defaults.camera_exposure = (255 * 15) / 0xFFFF;
+    defaults.camera_brightness = 0;
+    defaults.camera_mirror = PSMove_False;
+    defaults.exposure_mode = Exposure_LOW;
+    defaults.calibration_blink_delay = 200;
+    defaults.calibration_diff_t = 20;
+    defaults.calibration_min_size = 50;
+    defaults.calibration_max_distance = 30;
+    defaults.calibration_size_std = 10;
+    defaults.color_mapping_max_age = 2 * 60 * 60;
+    defaults.dimming_factor = 1.f;
+    defaults.color_hue_filter_range = 20;
+    defaults.color_saturation_filter_range = 85;
+    defaults.color_value_filter_range = 85;
+    defaults.tracker_adaptive_xy = 1;
+    defaults.tracker_adaptive_z = 1;
+    defaults.color_adaption_quality_t = 35.f;
+    defaults.color_update_rate = 1.f;
+    defaults.search_tile_width = 0;
+    defaults.search_tile_height = 0;
+    defaults.search_tiles_horizontal = 0;
+    defaults.search_tiles_count = 0;
+    defaults.roi_adjust_fps_t = 160;
+    defaults.tracker_quality_t1 = 0.3f;
+    defaults.tracker_quality_t2 = 0.7f;
+    defaults.tracker_quality_t3 = 4.7f;
+    defaults.color_update_quality_t1 = 0.8f;
+    defaults.color_update_quality_t2 = 0.2f;
+    defaults.color_update_quality_t3 = 6.f;
+	defaults.intrinsics_xml = "intrinsics.xml";
+	defaults.distortion_xml = "distortion.xml";
+
+	return defaults;
+}
+
+static const PSMoveTrackerSettings tracker_default_settings = create_tracker_default_settings();
 
 /**
  * Syntactic sugar - iterate over all valid controllers of a tracker

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -110,8 +110,6 @@ static const PSMoveTrackerSettings create_tracker_default_settings()
 	return defaults;
 }
 
-static const PSMoveTrackerSettings tracker_default_settings = create_tracker_default_settings();
-
 /**
  * Syntactic sugar - iterate over all valid controllers of a tracker
  *
@@ -392,7 +390,7 @@ psmove_tracker_remember_color(PSMoveTracker *tracker, struct PSMove_RGBValue rgb
 void
 psmove_tracker_settings_set_default(PSMoveTrackerSettings *settings)
 {
-    *settings = tracker_default_settings; 
+    *settings = create_tracker_default_settings(); 
 }
 
 PSMoveTracker *psmove_tracker_new() {

--- a/src/tracker/tracker_helpers.h
+++ b/src/tracker/tracker_helpers.h
@@ -46,6 +46,10 @@
                                ((a).y - (b).y) * \
                                ((a).y - (b).y))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Variance and average of an array of doubles
  *
@@ -87,5 +91,9 @@ th_scalar_mul(CvScalar a, double b);
  **/
 CvScalar
 th_brg2hsv(CvScalar bgr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // TRACKER_HELPERS_H


### PR DESCRIPTION
I've updated the Windows build to also use OpenCV 3.1 instead of the older 2.4.11 so that all platforms now use the same OpenCV version. I tried doing this a while ago as part of my VS2013 support work (https://github.com/thp/psmoveapi/pull/190), but back then I was seeing a crash when `cvGetSize` was called during `psmove_tracker_blinking_calibration`.

That crash is still there, but I've spent some time investigating the crash and it turns out it's caused by a bug in OpenCV that causes incorrect code to be generated when `cvGetSize` is called from a C source file under MSVC (it works fine when called from C++/other compilers).

I've opened a bug on OpenCV's tracker (https://github.com/Itseez/opencv/issues/6221) detailing my findings, but in the meantime, since `psmove_tracker.c` is the only file that uses `cvGetSize`, I've added a workaround to the CMake scripts for MSVC to force that file to be compiled as C++; this fixes the crash. I had to make some minor modifications to get it to compile as both C and C++.

Finally, I've also fixed a MingW build error introduced as part of https://github.com/thp/psmoveapi/pull/215; it should now build cleanly on all platforms again.
