### PR TITLE
Remove intrinsics.xml/distortion.xml from settings

### DIFF
--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -140,10 +140,6 @@ typedef struct {
     float color_update_quality_t1;              /* [0.8] minimum ratio of number of pixels in blob vs pixel of estimated circle. */
     float color_update_quality_t2;              /* [0.2] maximum allowed change of the radius in percent, compared to the last estimated radius */
     float color_update_quality_t3;              /* [6.f] minimum radius */
-
-	/* Camera calibration */
-	const char* intrinsics_xml;					/* [intrinsics.xml] File to read intrinsics matrix from */
-	const char* distortion_xml;					/* [distortion.xml] File to read distortion coefficients from */
 } PSMoveTrackerSettings; /*!< Structure for storing tracker settings */
 
 /**

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -378,8 +378,6 @@ psmove_tracker_settings_set_default(PSMoveTrackerSettings *settings)
     settings->color_update_quality_t1 = 0.8f;
     settings->color_update_quality_t2 = 0.2f;
     settings->color_update_quality_t3 = 6.f;
-    settings->intrinsics_xml = "intrinsics.xml";
-    settings->distortion_xml = "distortion.xml";
 }
 
 PSMoveTracker *psmove_tracker_new() {
@@ -565,8 +563,8 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
         return NULL;
     }
 
-	char *intrinsics_xml = psmove_util_get_file_path(settings->intrinsics_xml);
-	char *distortion_xml = psmove_util_get_file_path(settings->distortion_xml);
+	char *intrinsics_xml = psmove_util_get_file_path("intrinsics.xml");
+	char *distortion_xml = psmove_util_get_file_path("distortion.xml");
 	camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml);
 	free(intrinsics_xml);
 	free(distortion_xml);


### PR DESCRIPTION
Those strings are probably not going to change, and if they do,
we should properly manage the memory of the strings (strdup()
when set, and free() when closing), which makes memory management
of the settings unnecessarily complicated. Plus, it was all relative
to the PS Move API configuration directory, anyway.