### PR TITLE
Remove support for the CL Eye SDK

### DIFF
--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -11,9 +11,6 @@ option(PSMOVE_BUILD_TRACKER "Build the Tracker module (needs OpenCV)" ON)
 # Enable tweaks (e.g. registry settings on Windows, ...) for PS Eye
 option(PSMOVE_USE_PSEYE "Enable tweaks for the PS Eye camera" ON)
 
-# Use the CL Eye SDK to interface with the PS Eye camera (Windows only)
-option(PSMOVE_USE_CL_EYE_SDK "Use the CL Eye SDK driver on Windows" OFF)
-
 # Use the PS3EYEDriver to interface with the PS Eye camera (OS X and Windows only)
 option(PSMOVE_USE_PS3EYE_DRIVER "Use the PS3EYEDriver on OS X or Windows" OFF)
 
@@ -124,29 +121,6 @@ IF(PSMOVE_USE_PS3EYE_DRIVER)
     set(INFO_LICENSE "GPL")
 ENDIF()
 
-#CL_EYE_DRIVER
-set(INFO_USE_CL_EYE "No (Windows 32-bit only)")
-IF(PSMOVE_USE_PSEYE
-    AND PSMOVE_USE_CL_EYE_SDK
-    AND ${CMAKE_SYSTEM_NAME} MATCHES "Windows"
-    AND NOT(${CMAKE_C_SIZEOF_DATA_PTR} EQUAL 8))
-    find_path(CL_EYE_SDK_PATH Bin/CLEyeMulticam.dll
-        HINTS "C:/Program Files/Code Laboratories/CL-Eye Platform SDK"
-        "C:/Program Files (x86)/Code Laboratories/CL-Eye Platform SDK")
-    IF(CL_EYE_SDK_PATH)
-        add_definitions(-DCAMERA_CONTROL_USE_CL_DRIVER)
-        list(APPEND PSMOVEAPI_TRACKER_REQUIRED_LIBS CLEyeMulticam)
-        file(COPY ${CL_EYE_SDK_PATH}/Bin/CLEyeMulticam.dll
-            DESTINATION ${ROOT_DIR}/external/libs)
-        set(INFO_USE_CL_EYE_SDK "Yes (SDK version)")
-        # XXX: If this crashes, disable compiler optimizations
-    ELSE()  # Fall back to registry version
-        set(INFO_USE_CL_EYE_SDK "Yes (registry version)")
-    ENDIF()
-else()
-    SET(INFO_USE_CL_EYE_SDK "No")
-ENDIF()
-
 IF(PSMOVE_USE_DEBUG_CAPTURE)
     add_definitions(-DCAMERA_CONTROL_DEBUG_CAPTURED_IMAGE)
 ENDIF()
@@ -216,5 +190,4 @@ message("  Tracker")
 message("    Tracker library:  " ${INFO_BUILD_TRACKER})
 feature_use_info("PS Eye support:   " PSMOVE_USE_PSEYE)
 feature_use_info("HTML tracing:     " PSMOVE_USE_TRACKER_TRACE)
-message("    Use CL Eye SDK:   " ${INFO_USE_CL_EYE_SDK})
 message("    Use PS3EYEDriver: " ${INFO_USE_PS3EYE_DRIVER})

--- a/src/tracker/camera_control_private.h
+++ b/src/tracker/camera_control_private.h
@@ -38,11 +38,7 @@
 #    include <windows.h>
 #endif
 
-#if defined(CAMERA_CONTROL_USE_CL_DRIVER)
-#    include "../external/CLEye/CLEyeMulticam.h"
-#else
-#    define CL_DRIVER_REG_PATH "Software\\PS3EyeCamera\\Settings"
-#endif
+#define CL_DRIVER_REG_PATH "Software\\PS3EyeCamera\\Settings"
 
 #if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
 #    include "ps3eye_capi.h"
@@ -51,13 +47,6 @@
 struct _CameraControl {
 	int cameraID;
 	IplImage* frame3chUndistort;
-
-#if defined(CAMERA_CONTROL_USE_CL_DRIVER)
-	CLEyeCameraInstance camera;
-	IplImage* frame3ch;
-	IplImage* frame4ch;
-	PBYTE pCapBuffer;
-#endif
 
 #if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
         ps3eye_t *eye;

--- a/src/tracker/platform/camera_control_win32.c
+++ b/src/tracker/platform/camera_control_win32.c
@@ -38,7 +38,7 @@
 #include "../camera_control_private.h"
 
 void camera_control_backup_system_settings(CameraControl* cc, const char* file) {
-#if !defined(CAMERA_CONTROL_USE_CL_DRIVER) && !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER) && defined(PSMOVE_USE_PSEYE)
+#if !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER) && defined(PSMOVE_USE_PSEYE)
 	HKEY hKey;
 	DWORD l = sizeof(DWORD);
 	DWORD AutoAEC = 0;
@@ -80,7 +80,7 @@ void camera_control_backup_system_settings(CameraControl* cc, const char* file) 
 }
 
 void camera_control_restore_system_settings(CameraControl* cc, const char* file) {
-#if !defined(CAMERA_CONTROL_USE_CL_DRIVER) && !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER) && defined(PSMOVE_USE_PSEYE)
+#if !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER) && defined(PSMOVE_USE_PSEYE)
 	int NOT_FOUND = -1;
 	int val;
 	HKEY hKey;
@@ -132,26 +132,7 @@ void camera_control_restore_system_settings(CameraControl* cc, const char* file)
 
 void camera_control_set_parameters(CameraControl* cc, int autoE, int autoG, int autoWB, int exposure, int gain, int wbRed, int wbGreen, int wbBlue, int contrast, int brightness, enum PSMove_Bool h_flip)
 {
-#if defined(CAMERA_CONTROL_USE_CL_DRIVER)
-	if (autoE >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_AUTO_EXPOSURE, autoE > 0);
-	if (autoG >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_AUTO_GAIN, autoG > 0);
-	if (autoWB >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_AUTO_WHITEBALANCE, autoWB > 0);
-	if (exposure >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_EXPOSURE, round((511 * exposure) / 0xFFFF));
-	if (gain >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_GAIN, round((79 * gain) / 0xFFFF));
-	if (wbRed >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_WHITEBALANCE_RED, round((255 * wbRed) / 0xFFFF));
-	if (wbGreen >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_WHITEBALANCE_GREEN, round((255 * wbGreen) / 0xFFFF));
-	if (wbBlue >= 0)
-		CLEyeSetCameraParameter(cc->camera, CLEYE_WHITEBALANCE_BLUE, round((255 * wbBlue) / 0xFFFF));
-
-	CLEyeSetCameraParameter(cc->camera, CLEYE_HFLIP, h_flip)
-#elif defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
+#if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
 	//autoE... setAutoExposure not defined in ps3eye.h
 	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN,				autoG > 0);
 	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE,		autoWB > 0);

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -1225,7 +1225,7 @@ void psmove_tracker_update_image(PSMoveTracker *tracker) {
     tracker->frame = camera_control_query_frame(tracker->cc,
             &(tracker->ts_camera_grab), &(tracker->ts_camera_retrieve));
 
-#if !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER) && !defined(CAMERA_CONTROL_USE_CL_DRIVER)
+#if !defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
 	// We only need to flip here if we're using OpenCV to capture, since the PS3EyeDriver and CLEyeDriver support flipping in hardware (see camera_control_set_parameters)
     if (tracker->settings.camera_mirror) {
         /**


### PR DESCRIPTION
The CL Eye Driver is still supported on Windows, but
the specific CL Eye SDK is not used anymore here.