### PR TITLE
Remove references to old Madgwick AHRS implementation

### DIFF
--- a/README
+++ b/README
@@ -109,16 +109,9 @@ on your options at configure time.
 In general, all dependencies are under a MIT- or BSD-style license, with the
 exception of the following dependencies:
 
- - Madgwick AHRS: Released under the terms of the GNU GPL
-   For orientation tracking
-   CMake option: PSMOVE_USE_MADGWICK_AHRS (disabled by default)
-
  - PS3EYEDriver: Released under the MIT license, parts based on GPL code
    For interfacing with the PSEye camera on OS X (only in the tracker)
    CMake option: PSMOVE_USE_PS3EYE_DRIVER (disabled by default)
-
-When you enable the Madgwick AHRS algorithm, the resulting library can only
-be used under the terms of the GNU GPL.
 
 More information about the third party modules and licenses:
 

--- a/contrib/build_scripts/msvc/build_msvc_common.bat
+++ b/contrib/build_scripts/msvc/build_msvc_common.bat
@@ -167,14 +167,14 @@ IF NOT EXIST build mkdir build
 cd build
 
 IF "%MSVC_VERSION%"=="2015" (
-	cmake .. -G "Visual Studio 14 Win64" -DPSMOVE_USE_MADGWICK_AHRS=1 -DPSMOVE_USE_PS3EYE_DRIVER=1 -DPSMOVE_BUILD_OPENGL_EXAMPLES=1 -DOpenCV_DIR=./external/opencv/build/ -DSDL2DIR=./external/SDL2/
+	cmake .. -G "Visual Studio 14 Win64" -DPSMOVE_USE_PS3EYE_DRIVER=1 -DPSMOVE_BUILD_OPENGL_EXAMPLES=1 -DOpenCV_DIR=./external/opencv/build/ -DSDL2DIR=./external/SDL2/
 	IF !ERRORLEVEL! NEQ 0 (
 		echo Failed to generate PSMoveAPI solution
 		goto Error
 	)	
 ) ELSE (
 	IF "%MSVC_VERSION%" == "2013" (
-		cmake .. -G "Visual Studio 12 Win64" -DPSMOVE_USE_MADGWICK_AHRS=1 -DPSMOVE_USE_PS3EYE_DRIVER=1 -DPSMOVE_BUILD_OPENGL_EXAMPLES=1 -DOpenCV_DIR=./external/opencv/build/ -DSDL2DIR=./external/SDL2/
+		cmake .. -G "Visual Studio 12 Win64" -DPSMOVE_USE_PS3EYE_DRIVER=1 -DPSMOVE_BUILD_OPENGL_EXAMPLES=1 -DOpenCV_DIR=./external/opencv/build/ -DSDL2DIR=./external/SDL2/
 		IF !ERRORLEVEL! NEQ 0 ( 
 			echo Failed to generate PSMoveAPI solution
 			goto Error

--- a/external/README
+++ b/external/README
@@ -6,16 +6,6 @@ by Alan Ott
 from http://www.signal11.us/oss/hidapi/
 
 
-MadgwickAHRS, MahonyAHRS
-========================
-
-Open Source IMU and AHRS algorithms
-by Sebastian Madgwick
-from http://www.x-io.co.uk/node/8
-
-Modified by Thomas Perl for multi-controller tracking (quaternion state)
-
-
 iniparser
 =========
 


### PR DESCRIPTION
The Madgwick AHRS algorithm is still used, but implemented
freshly for PS Move API in src/psmove_orientation.cpp these
days, so remove the remaining references in the README files
and in the MSVC build script (the option doesn't exist anymore).