### PR TITLE
PS3EyeDriver Update

### DIFF
--- a/src/tracker/platform/camera_control_win32.c
+++ b/src/tracker/platform/camera_control_win32.c
@@ -112,9 +112,9 @@ void camera_control_set_parameters(CameraControl* cc, int autoE, int autoG, int 
 	//autoE... setAutoExposure not defined in ps3eye.h
 	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN,				autoG > 0);
 	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE,		autoWB > 0);
-	ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE,				(int)round((511 * exposure) / 0xFFFF));
-	ps3eye_set_parameter(cc->eye, PS3EYE_GAIN,					(int)round((79 * gain) / 0xFFFF));
-	ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS,			(int)round((255 * brightness) / 0xFFFF));
+	ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE,				(int)((511 * exposure) / 0xFFFF));
+	ps3eye_set_parameter(cc->eye, PS3EYE_GAIN,					(int)((79 * gain) / 0xFFFF));
+	ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS,			(int)((255 * brightness) / 0xFFFF));
 	ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, 				h_flip);
 	
 	//ps3eye_set_parameter(cc->eye, PS3EYE_REDBALANCE, round((255 * wbRed) / 0xFFFF));


### PR DESCRIPTION
I've spent some time further optimizing PS3EyeDriver. I've switched the driver to use Bayer (RAW) mode as output from the camera, instead of the previous YUV422. This significantly (halves) the required bandwidth, which is especially significant for usage of multiple cameras on 1 machine.

As part of that optimization, the driver can now output frame data in the desired format (it does color conversion internally), rather than the client having to do that. So I've updated the camera_control stuff to remove the yuv->bgr conversion. See https://github.com/inspirit/PS3EYEDriver/pull/33 for more information.

This change may make it interesting to use the PS3EyeDriver on Linux as well, since the performance is now way better than the driver built-in to the kernel. But I'm not working on Linux, so I'll leave that change for somebody else to make, if desired.

Finally, I stumbled across a different bug: exposure was always being set to zero on windows. This seems to be caused by the usage of the `round` function in `camera_control_set_parameters` (it always returned zero, don't know why), so I just removed the usage of `round`, since it seems unneccessary anyway.

Unfortunately, I committed & pushed this change to the master branch by accident, so I'm sending a PR from my master branch, instead of different branch specific to this change. I didn't know how to fix that. Sorry.