### PR TITLE
add Archlinux to Systemd distributions

### DIFF
--- a/src/platform/psmove_linuxsupport.c
+++ b/src/platform/psmove_linuxsupport.c
@@ -324,7 +324,8 @@ void linux_info_init(struct linux_info_t *info)
             *q = 0;
 
             if ((!strcmp(value, "openSUSE")) ||
-                (!strcmp(value, "Fedora"))) {
+                (!strcmp(value, "Fedora")) ||
+                (!strcmp(value, "Arch Linux"))) {
                     // all recent versions of openSUSE and Fedora use
                     // systemd
                     info->init_type = LINUX_SYSTEMD;


### PR DESCRIPTION
Maybe using a more generic method to find out whether the system is currently booted with systemd would be better (I'm sure e.g. gentoo has systemd too).

For example
```c
if (system("init --version | grep systemd > /dev/null 2> /dev/null") == 0) {
```
seems to work but there is probably a better way.