### PR TITLE
Separate registering controllers from pairing

### DIFF
--- a/include/psmove.h
+++ b/include/psmove.h
@@ -416,6 +416,14 @@ ADDAPI enum PSMove_Bool
 ADDCALL psmove_pair(PSMove *move);
 
 /**
+ * \brief Add an entry for a controller paired on another host.
+ *
+ * \param addr The Bluetooth address of the PS move to add
+ **/
+ADDAPI enum PSMove_Bool
+ADDCALL psmove_host_pair_custom(const char *addr);
+
+/**
  * \brief Pair a controller connected via USB to a specific address.
  *
  * This function behaves the same as psmove_pair(), but allows you to

--- a/src/platform/psmove_linuxsupport.c
+++ b/src/platform/psmove_linuxsupport.c
@@ -394,7 +394,7 @@ void linux_bluetoothd_control(struct linux_info_t *info, int start)
 }
 
 int
-linux_bluez_register_psmove(char *addr, char *host)
+linux_bluez_register_psmove(const char *addr, const char *host)
 {
     int errors = 0;
     char *base = NULL;

--- a/src/platform/psmove_linuxsupport.h
+++ b/src/platform/psmove_linuxsupport.h
@@ -4,6 +4,6 @@
 #include "psmove.h"
 
 int
-linux_bluez_register_psmove(char *addr, char *host);
+linux_bluez_register_psmove(const char *addr, const char *host);
 
 #endif

--- a/src/platform/psmove_port_osx.c
+++ b/src/platform/psmove_port_osx.c
@@ -29,6 +29,8 @@
 
 #include "psmove_port.h"
 #include "psmove_sockets.h"
+#include "psmove_osxsupport.h"
+#include "psmove_private.h"
 
 #include <unistd.h>
 #include <sys/time.h>
@@ -87,4 +89,17 @@ void
 psmove_port_close_socket(int socket)
 {
     close(socket);
+}
+
+char *
+psmove_port_get_host_bluetooth_address()
+{
+    return macosx_get_btaddr();
+}
+
+void
+psmove_port_register_psmove(const char *addr, const char *host)
+{
+    /* Add entry to the com.apple.Bluetooth.plist file */
+    macosx_blued_register_psmove(addr);
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,7 +4,7 @@ include(${ROOT_DIR}/cmake/common.cmake)
 
 # Essential utilities
 include_directories(${ROOT_DIR}/src)
-foreach(UTILITY moved psmovepair magnetometer_calibration)
+foreach(UTILITY moved psmovepair magnetometer_calibration psmoveregister)
     add_executable(${UTILITY} ${CMAKE_CURRENT_LIST_DIR}/${UTILITY}.c)
     target_link_libraries(${UTILITY} psmoveapi_static)
     set_target_properties(${UTILITY} PROPERTIES

--- a/src/utils/psmoveregister.c
+++ b/src/utils/psmoveregister.c
@@ -1,6 +1,7 @@
-/**
+
+ /**
  * PS Move API - An interface for the PS Move Motion Controller
- * Copyright (c) 2016 Thomas Perl <m@thp.io>
+ * Copyright (c) 2011, 2016 Thomas Perl <m@thp.io>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,66 +27,35 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_PORT_H
-#define PSMOVE_PORT_H
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "psmove.h"
+#include "../psmove_private.h"
+#include "../psmove_port.h"
 
-#include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Initialize sockets API (if required) -- call before using sockets */
-void
-psmove_port_initialize_sockets();
-
-/**
- * Check if necessary permissions are available for pairing controllers
- * Returns non-zero if permissions are available, zero if not
- **/
 int
-psmove_port_check_pairing_permissions();
+main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s [bluetooth-address]\n", argv[0]);
+        return 1;
+    }
 
-/**
- * Get the current time in milliseconds since the first call
- **/
-ADDAPI uint64_t
-ADDCALL psmove_port_get_time_ms();
+    if (!psmove_port_check_pairing_permissions()) {
+        return 1;
+    }
 
-/**
- * Sleep for a specified amount of milliseconds
- **/
-ADDAPI void
-ADDCALL psmove_port_sleep_ms(uint32_t duration_ms);
+    if (psmove_host_pair_custom(argv[1])) {
+        printf("Paired\n");
+    } else {
+        printf("Pairing failed\n");
+    }
 
-/**
- * Set the timeout to the specified time in milliseconds for a given socket
- **/
-void
-psmove_port_set_socket_timeout_ms(int socket, uint32_t timeout_ms);
-
-/**
- * Close a socket
- **/
-void
-psmove_port_close_socket(int socket);
-
-/**
- * Get the default Bluetooth host controller address (result must be freed)
- **/
-char *
-psmove_port_get_host_bluetooth_address();
-
-/**
- * Add the PS Move Bluetooth controller address to the system database
- **/
-void
-psmove_port_register_psmove(const char *addr, const char *host);
-
-#ifdef __cplusplus
+    return 0;
 }
-#endif
-
-#endif /* PSMOVE_PORT_H */


### PR DESCRIPTION
This allows adding the correct BlueZ entries on a host for a given controller even if the controller has been paired on another host.