### PR TITLE
Convert include guards to #pragma once

### DIFF
--- a/contrib/convert-include-guards.py
+++ b/contrib/convert-include-guards.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Convert include guards to #pragma once
+# Thomas Perl; 2016-12-04
+
+import sys
+import re
+import shutil
+
+for filename in sys.argv[1:]:
+    d = open(filename).read()
+    if '#pragma once' in d:
+        print('Already converted:', filename)
+        continue
+
+    matches = re.findall('(#ifndef (.*)\n#define \\2\n)(?:.|\n)*(\n#endif(?:.*\\2.*)?\s*)$', d)
+    if not matches:
+        print('Could not find matches:', filename)
+
+    for header, _, footer in matches:
+        print('Converting:', filename)
+        shutil.copy(filename, filename + '.bak')
+        # Remove any trailing whitespace, but add newline at end of file
+        d = '#pragma once\n' + d[:-len(footer)].rstrip().replace(header, '') + '\n'
+        open(filename, 'w').write(d)

--- a/include/psmove.h
+++ b/include/psmove.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef __PSMOVE_H
-#define __PSMOVE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -1508,6 +1507,3 @@ ADDCALL psmove_util_get_env_string(const char *name);
 #ifdef __cplusplus
 }
 #endif
-
-#endif
-

--- a/include/psmove_config.h.in
+++ b/include/psmove_config.h.in
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -27,12 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_CONFIG_H
-#define PSMOVE_CONFIG_H
 
 /* This file is auto-generated from psmove_config.h.in by CMake */
 
 #cmakedefine PSMOVE_BUILD_TRACKER
 #cmakedefine PSMOVE_USE_PSEYE
-
-#endif

--- a/include/psmove_fusion.h
+++ b/include/psmove_fusion.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef PSMOVE_FUSION_H
-#define PSMOVE_FUSION_H
 
 #include "psmove_config.h"
 #include "psmove.h"
@@ -135,5 +134,3 @@ ADDCALL psmove_fusion_free(PSMoveFusion *fusion);
 #ifdef __cplusplus
 };
 #endif
-
-#endif /* PSMOVE_FUSION_H */

--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Benjamin Venditti <benjamin.venditti@gmail.com>
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_TRACKER_H
-#define PSMOVE_TRACKER_H
 
 #include "psmove_config.h"
 #include "psmove.h"
@@ -667,6 +666,4 @@ ADDCALL psmove_tracker_free(PSMoveTracker *tracker);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/daemon/moved_client.h
+++ b/src/daemon/moved_client.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef MOVED_CLIENT_H
-#define MOVED_CLIENT_H
 
 
 #include "../psmove_sockets.h"
@@ -72,5 +71,3 @@ moved_client_send(moved_client *client, char req, char id, const unsigned char *
 
 void
 moved_client_destroy(moved_client *client);
-
-#endif

--- a/src/daemon/moved_monitor.h
+++ b/src/daemon/moved_monitor.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef MOVED_MONITOR_H
-#define MOVED_MONITOR_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,5 +80,3 @@ moved_monitor_free(moved_monitor *monitor);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* MOVED_MONITOR_H */

--- a/src/daemon/psmove_moved_protocol.h
+++ b/src/daemon/psmove_moved_protocol.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef MOVED_PROTOCOL_H
-#define MOVED_PROTOCOL_H
 
 #define MOVED_UDP_PORT 17777
 
@@ -48,5 +47,3 @@
 
 /* Maximum number of retries for client requests */
 #define MOVED_MAX_RETRIES 5
-
-#endif

--- a/src/math/psmove_math.h
+++ b/src/math/psmove_math.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
 * PS Move API - An interface for the PS Move Motion Controller
 * Copyright (c) 2011, 2012 Thomas Perl <m@thp.io>
@@ -27,8 +28,6 @@
 **/
 
 /* General math utility functions */
-#ifndef __PSMOVE_MATH_H
-#define __PSMOVE_MATH_H
 
 //-- includes -----
 #include <float.h>
@@ -76,6 +75,4 @@ float radians_to_degrees(float x);
 
 #ifdef __cplusplus
 }
-#endif	
-
-#endif // __PSMOVE_MATH_H
+#endif

--- a/src/math/psmove_vector.h
+++ b/src/math/psmove_vector.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
 * PS Move API - An interface for the PS Move Motion Controller
 * Copyright (c) 2011, 2012 Thomas Perl <m@thp.io>
@@ -27,8 +28,6 @@
 **/
 
 /* Math functions related to 3d vectors */
-#ifndef __PSMOVE_VECTOR_H
-#define __PSMOVE_VECTOR_H
 
 //-- includes -----
 #include <stdbool.h>
@@ -105,5 +104,3 @@ ADDCALL psmove_3axisvector_apply_transform(const PSMove_3AxisVector *v, const PS
 //-- macros -----
 #define assert_vector_is_normalized(v) assert(is_nearly_equal(psmove_vector_length_squared(v), 1.f, k_normal_epsilon))
 #define assert_vectors_are_perpendicular(a, b) assert(is_nearly_equal(psmove_vector_dot(a,b), 0.f, k_normal_epsilon))
-
-#endif // __PSMOVE_VECTOR_H

--- a/src/psmove_calibration.h
+++ b/src/psmove_calibration.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef PSMOVE_CALIBRATION_H
-#define PSMOVE_CALIBRATION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,6 +107,4 @@ ADDCALL psmove_calibration_free(PSMoveCalibration *calibration);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/psmove_orientation.h
+++ b/src/psmove_orientation.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef PSMOVE_ORIENTATION_H
-#define PSMOVE_ORIENTATION_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -100,6 +99,4 @@ ADDCALL psmove_orientation_reset_quaternion(PSMoveOrientation *orientation_state
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/psmove_port.h
+++ b/src/psmove_port.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2016 Thomas Perl <m@thp.io>
@@ -26,8 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_PORT_H
-#define PSMOVE_PORT_H
 
 #include "psmove.h"
 
@@ -117,5 +116,3 @@ psmove_port_register_psmove(const char *addr, const char *host);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* PSMOVE_PORT_H */

--- a/src/psmove_private.h
+++ b/src/psmove_private.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Thomas Perl <m@thp.io>
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_PRIVATE_H
-#define PSMOVE_PRIVATE_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -234,6 +233,4 @@ ADDCALL _psmove_get_auth_response(PSMove *move);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/psmove_sockets.h
+++ b/src/psmove_sockets.h
@@ -1,3 +1,4 @@
+#pragma once
 
 /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef PSMOVE_SOCKETS_H
-#define PSMOVE_SOCKETS_H
 
 #ifdef _WIN32
 #  include <winsock2.h>
@@ -42,5 +41,3 @@
 #  include <sys/socket.h>
 #  include <sys/types.h>
 #endif
-
-#endif /* PSMOVE_SOCKETS_H */

--- a/src/tracker/camera_control.h
+++ b/src/tracker/camera_control.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Benjamin Venditti <benjamin.venditti@gmail.com>
@@ -26,8 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef CAMERA_CONTROL_H_
-#define CAMERA_CONTROL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,6 +110,3 @@ camera_control_restore_system_settings(CameraControl* cc,
 #ifdef __cplusplus
 }
 #endif
-
-
-#endif /* CAMERA_CONTROL_H_ */

--- a/src/tracker/camera_control_private.h
+++ b/src/tracker/camera_control_private.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Thomas Perl <m@thp.io>
@@ -27,8 +29,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef CAMERA_CONTROL_PRIV_H
-#define CAMERA_CONTROL_PRIV_H
 
 #include "opencv2/core/core_c.h"
 #include "opencv2/highgui/highgui_c.h"
@@ -62,8 +62,6 @@ struct _CameraControl {
         int height;
         enum PSMove_Bool deinterlace;
 };
-
-#endif
 
 void
 get_metrics(int *width, int *height);

--- a/src/tracker/platform/psmove_linuxsupport.h
+++ b/src/tracker/platform/psmove_linuxsupport.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef PSMOVE_TRACKER_LINUXSUPPORT_H
-#define PSMOVE_TRACKER_LINUXSUPPORT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +41,4 @@ linux_find_pseye();
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/tracker/platform/psmove_osxsupport.h
+++ b/src/tracker/platform/psmove_osxsupport.h
@@ -1,3 +1,4 @@
+#pragma once
 
  /**
  * PS Move API - An interface for the PS Move Motion Controller
@@ -28,8 +29,6 @@
  **/
 
 
-#ifndef PSMOVE_TRACKER_OSXSUPPORT_H
-#define PSMOVE_TRACKER_OSXSUPPORT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +42,4 @@ macosx_camera_set_exposure_lock(int locked);
 
 #ifdef __cplusplus
 }
-#endif
-
 #endif

--- a/src/tracker/tracker_helpers.h
+++ b/src/tracker/tracker_helpers.h
@@ -1,3 +1,4 @@
+#pragma once
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Benjamin Venditti <benjamin.venditti@gmail.com>
@@ -27,8 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  **/
 
-#ifndef TRACKER_HELPERS_H
-#define TRACKER_HELPERS_H
 
 #include "opencv2/core/core_c.h"
 
@@ -95,5 +94,3 @@ th_brg2hsv(CvScalar bgr);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // TRACKER_HELPERS_H


### PR DESCRIPTION
Automatically converted using:

    zsh% python3 contrib/convert-include-guards.py include/* src/**/*.h

Manually converted `src/tracker/camera_control_private.h`, which had broken include guards (trailing data after `#endif`).