### PR TITLE
Fix size search for psmove_fusion_get_position()

### DIFF
--- a/src/tracker/psmove_fusion.cpp
+++ b/src/tracker/psmove_fusion.cpp
@@ -139,7 +139,7 @@ psmove_fusion_get_position(PSMoveFusion *fusion, PSMove *move,
         glm::vec3 right = glm::project(glm::vec3(obj.x + .5, obj.y, obj.z),
                 glm::mat4(), fusion->projection, fusion->viewport);
 
-        float width = (right.x - left.x);
+        float width = std::abs(right.x - left.x);
         if (width > targetWidth) {
             /* Too near */
             winZ += step;


### PR DESCRIPTION
Ideally we would convert this to a single calculation and remove the binary search, but this is just a quick fix.