### PR TITLE
Improve macOS Bluetooth pairing

### DIFF
--- a/src/platform/psmove_port_osx.m
+++ b/src/platform/psmove_port_osx.m
@@ -56,6 +56,10 @@ macosx_bluetooth_set_powered(int powered)
     // Inspired by blueutil from Frederik Seiffert <ego@frederikseiffert.de>
     int state = IOBluetoothPreferenceGetControllerPowerState();
 
+    if (state == powered) {
+        return 1;
+    }
+
     OSXPAIR_DEBUG("Switching Bluetooth %s...\n", powered?"on":"off");
     IOBluetoothPreferenceSetControllerPowerState(powered);
 

--- a/src/platform/psmove_port_osx.m
+++ b/src/platform/psmove_port_osx.m
@@ -91,6 +91,15 @@ macosx_get_btaddr()
     result = strdup([addr UTF8String]);
     psmove_return_val_if_fail(result != NULL, NULL);
 
+    char *tmp = result;
+    while (*tmp) {
+        if (*tmp == '-') {
+            *tmp = ':';
+        }
+
+        tmp++;
+    }
+
     [pool release];
     return result;
 }


### PR DESCRIPTION
Do not log / start up Bluetooth if it's already running.
Normalize Bluetooth address string returned by the get Bluetooth address function.