### PR TITLE
Do not build against GStreamer on macOS

### DIFF
--- a/contrib/build_scripts/osx/build-osx-snapshot
+++ b/contrib/build_scripts/osx/build-osx-snapshot
@@ -77,6 +77,7 @@ if [ ! -d $OPENCV_INSTALL_DIR ]; then
           -DWITH_OPENEXR=OFF \
           -DWITH_FFMPEG=OFF \
           -DWITH_JASPER=OFF \
+          -DWITH_GSTREAMER=OFF \
           -DWITH_GPHOTO2=OFF \
           -DCMAKE_OSX_ARCHITECTURES="x86_64" \
           -DCMAKE_INSTALL_PREFIX=$(pwd)/install ..


### PR DESCRIPTION
Linking step fails when OpenCV is built against GStreamer on macOS (`brew install gstreamer`).