### PR TITLE
Fix system-wide calibration loading; warn if missing

### DIFF
--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -491,9 +491,10 @@ psmove_calibration_load(PSMoveCalibration *calibration)
         // use system file in case local is not available
         fp = fopen(calibration->system_filename, "rb");
         if (fp == NULL) {
+            psmove_WARNING("No calibration file found (%s or %s)\n",
+                    calibration->filename, calibration->system_filename);
             return 0;
         }
-        return 0;
     }
 
     if (fread(calibration->usb_calibration,


### PR DESCRIPTION
We must not `return 0;` if the system-wide file was successfully loaded. Also, since proper operation of most of the API depends on the calibration data being available, warn if it is not available.