### PR TITLE
macOS: Do not show password prompt for sudo/setuid

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,7 +68,7 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/mac/hid.c)
 
     list(APPEND PSMOVEAPI_PLATFORM_SRC
-        ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_osx.m)
+        ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_osx.mm)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")


### PR DESCRIPTION
If the current effective user id is already 0 (i.e. root using sudo or setuid bit), we can run the `defaults write` command directly without going through `osascript`. This allows easy pairing without GUI interaction for some cases.