### PR TITLE
Do not include cloning in build instructions (Fixes #286)

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -11,11 +11,9 @@ You need to install the following requirements:
 
 .. _`Homebrew`: http://brew.sh/
 
-Install the dependencies and clone the source repository::
+Install the dependencies::
 
-    brew install cmake git libtool automake
-    git clone --recursive git://github.com/thp/psmoveapi.git
-    cd psmoveapi
+    brew install cmake libtool automake
 
 To build from source, you can use the build script::
 
@@ -24,32 +22,6 @@ To build from source, you can use the build script::
 
 Building on Ubuntu 14.04
 ------------------------
-
-The commands are entered into the Terminal (use Ctrl+Alt+T to open one).
-
-We assume that you are going to clone the repository into::
-
-    ~/src/psmoveapi/
-
-
-Preparing to build the PS Move API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Upgrade your system to the latest packages::
-
-    sudo apt-get update
-    sudo apt-get dist-upgrade
-
-2. Install Git::
-
-    sudo apt-get install git
-
-3. Clone the PS Move API Repository::
-
-    mkdir -p ~/src/
-    cd ~/src/
-    git clone --recursive git://github.com/thp/psmoveapi.git
-    cd psmoveapi
 
 Automatic build
 ~~~~~~~~~~~~~~~
@@ -88,20 +60,10 @@ You need to install the following requirements:
 
 - `Visual Studio Community 2013`_ or `Visual Studio Community 2015`_
 - `CMake`_
-- `Git`_
 
 .. _`Visual Studio Community 2013`: http://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx
 .. _`Visual Studio Community 2015`: https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx
 .. _`CMake`: http://www.cmake.org/cmake/resources/software.html
-.. _`Git`: http://code.google.com/p/msysgit/
-
-Preparing to build the PS Move API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Clone the PS Move API repository::
-
-   git clone --recursive https://github.com/thp/psmoveapi.git
-   cd psmoveapi
 
 Automatic build
 ~~~~~~~~~~~~~~~
@@ -167,10 +129,8 @@ WIFI, a standard-sized USB port and a 3.5mm headphone jack, making it
 suitable for portable PS Move applications.
 
 To build on a Pocket C.H.I.P, ``ssh`` into your device (or use the Terminal)
-and then clone the repository and build the release tarball::
+and then build the release tarball::
 
-    git clone --recursive git://github.com/thp/psmoveapi.git
-    cd psmoveapi
     bash -e -x scripts/pocketchip/install_dependencies.sh
     bash -e -x scripts/pocketchip/build.sh
 
@@ -192,8 +152,5 @@ A kernel with hidraw will print something like the following::
 
     [    1.265000] hidraw: raw HID events driver (C) Jiri Kosina
 
-If your kernel does not have hidraw support, and it is version **4.4.13-ntc-mlc**,
-you can `download a patched kernel`_; note that you should install the newest
+If your kernel does not have hidraw support, you should install the newest
 Firmware for your Pocket C.H.I.P, and make sure to install all updates via ``apt``.
-
-.. _`download a patched kernel`: https://thp.itch.io/pocket-chip-hidraw


### PR DESCRIPTION
Everyone should know how to clone the source repo or get the source tarball.