### PR TITLE
hidapi: Use Windows 10 fixes by cboulay (Fixes #214)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/hidapi"]
 	path = external/hidapi
-	url = git://github.com/signal11/hidapi.git
+	url = git://github.com/thp/hidapi.git
 [submodule "external/PS3EYEDriver"]
 	path = external/PS3EYEDriver
 	url = git://github.com/inspirit/PS3EYEDriver.git


### PR DESCRIPTION
Until it's fixed in upstream (https://github.com/signal11/hidapi/pull/219), let's use hidapi patched with cbuolay's fixes applied. I've verified that this makes psmoveapi work on Windows 10.

Fixes: https://github.com/thp/psmoveapi/issues/214