### PR TITLE
Include linker stubs for MSVC builds (Fixes #210)

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -108,7 +108,9 @@ case "$BUILD_TYPE" in
         "
         PLATFORM_LIB="
         $BUILDDIR/Release/psmoveapi.dll
+        $BUILDDIR/Release/psmoveapi.lib
         $BUILDDIR/Release/psmoveapi_tracker.dll
+        $BUILDDIR/Release/psmoveapi_tracker.lib
         "
         pkg_zipfile_7z
 


### PR DESCRIPTION
Right now only for the MSVC builds, since those are most likely used for linking against when building something with MSVC (the `.lib` stubs are not yet included with the MinGW builds).