### PR TITLE
Install Python to macOS, so 'pip' works

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -33,9 +33,9 @@ case "$UNAME" in
         ;;
     Darwin)
         brew update
-        brew install --force cmake git libtool automake autoconf swig || true
+        brew install --force cmake git libtool automake autoconf swig python || true
         brew unlink libtool ; brew link --overwrite libtool
-        pip install --user sphinx
+        pip2 install --user sphinx
         ;;
     *)
         echo "Unknown OS: $UNAME"


### PR DESCRIPTION
Install `python` via Homebrew and use `pip2` for installing Sphinx.