### PR TITLE
Require OpenCV 2.x in CMake

### DIFF
--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -28,7 +28,7 @@ ENDIF()
 
 # 1 - OpenCV
 IF(PSMOVE_BUILD_TRACKER)
-    FIND_PACKAGE(OpenCV QUIET)
+    FIND_PACKAGE(OpenCV 2 QUIET)
     IF(OpenCV_FOUND)
         IF ("${OpenCV_LIBS}" STREQUAL "")
             message("OpenCV Libs was empty! Manually setting.")


### PR DESCRIPTION
PS Move API won't work with OpenCV 3, so this makes sure to build with
the correct version.