### PR TITLE
Finishing up support the the ZCM2 PSMove controller

### DIFF
--- a/include/psmove.h
+++ b/include/psmove.h
@@ -381,6 +381,21 @@ ADDAPI char *
 ADDCALL psmove_get_serial(PSMove *move);
 
 /**
+ * \brief Get the model type (ZCM1 or ZCM2) of a controller.
+ *
+ * There are two primary version of the PSMove controller.
+ * The ZCM1 is the original PSMove controller that shipped with the PS3.
+ * The ZCM2 is the newer PSMove controller that shipped with the PS4.
+ * The most important difference is that ZCM2 does not have a magnetometer.
+ *
+ * \param move A valid \ref PSMove handle
+ *
+ * \return The \ref PSMove_Model_Type type of the controller
+ **/
+ADDAPI enum PSMove_Model_Type
+ADDCALL psmove_get_model(PSMove *move);
+
+/**
  * \brief Pair a controller connected via USB with the computer.
  *
  * This function assumes that psmove_connection_type() returns

--- a/src/platform/psmove_port_windows.c
+++ b/src/platform/psmove_port_windows.c
@@ -294,6 +294,163 @@ is_connection_established(const HANDLE hRadio, BLUETOOTH_DEVICE_INFO *device_inf
     return 1;
 }
 
+struct BluetoothAuthenticationCallbackState
+{
+    HANDLE hRadio;
+    BLUETOOTH_DEVICE_INFO *deviceInfo;
+    HANDLE hAuthenticationCompleteEvent;
+};
+
+static BOOL CALLBACK 
+bluetooth_auth_callback(
+    LPVOID pvParam, 
+    PBLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS pAuthCallbackParams)
+{
+    struct BluetoothAuthenticationCallbackState *state= (struct BluetoothAuthenticationCallbackState *)pAuthCallbackParams;
+
+    BLUETOOTH_AUTHENTICATE_RESPONSE AuthRes;
+    memset(&AuthRes, 0, sizeof(BLUETOOTH_AUTHENTICATE_RESPONSE));
+    AuthRes.authMethod = pAuthCallbackParams->authenticationMethod;
+    AuthRes.bthAddressRemote = pAuthCallbackParams->deviceInfo.Address;
+    AuthRes.negativeResponse = 0;
+
+    // Send authentication response to authenticate device
+    DWORD dwRet = BluetoothSendAuthenticationResponseEx(state->hRadio, &AuthRes);
+    if (dwRet == ERROR_SUCCESS)
+    {
+        // Flag the device as authenticated
+        WINPAIR_DEBUG("Bluetooth device authenticated!");
+        state->deviceInfo->fAuthenticated = TRUE;
+    }
+    else
+    {
+        if (dwRet == ERROR_CANCELLED)
+        {
+            WINPAIR_DEBUG("Bluetooth device denied passkey response");
+        }
+        else if (dwRet == E_FAIL)
+        {
+            WINPAIR_DEBUG("Failure during authentication");
+        }
+        else if (dwRet == ERROR_NOT_READY)
+        {
+            WINPAIR_DEBUG("Device not ready");
+        }
+        else if (dwRet == ERROR_INVALID_PARAMETER)
+        {
+            WINPAIR_DEBUG("Invalid parameter");
+        }		
+        else if (dwRet == 1244)
+        {
+            WINPAIR_DEBUG("Not authenticated");
+        }
+        else
+        {
+            WINPAIR_DEBUG("BluetoothSendAuthenticationResponseEx failed: %d", GetLastError());
+        }
+    }
+
+    // Signal the thread that the authentication callback completed
+    if (!SetEvent(state->hAuthenticationCompleteEvent)) 
+    {
+        WINPAIR_DEBUG("Failed to set event: %d", GetLastError());
+    }
+
+    return TRUE;
+}
+
+static int
+authenticate_controller(
+    HANDLE hRadio,
+    BLUETOOTH_DEVICE_INFO *device_info)
+{
+    int ret;
+
+    if (device_info->fAuthenticated == 0)
+    {
+        struct BluetoothAuthenticationCallbackState callbackState;
+        callbackState.deviceInfo= device_info;
+        callbackState.hAuthenticationCompleteEvent= INVALID_HANDLE_VALUE;
+        callbackState.hRadio= hRadio;
+
+        // Register authentication callback before starting authentication request
+        HBLUETOOTH_AUTHENTICATION_REGISTRATION hRegHandle = 0;
+        DWORD dwRet = BluetoothRegisterForAuthenticationEx(
+            device_info, &hRegHandle, &bluetooth_auth_callback, &callbackState);
+
+        if (dwRet == ERROR_SUCCESS)
+        {
+            callbackState.hAuthenticationCompleteEvent = CreateEvent( 
+                NULL,               // default security attributes
+                TRUE,               // manual-reset event
+                FALSE,              // initial state is non-signaled
+                TEXT("AuthenticationCompleteEvent"));  // object name
+
+            // Start the authentication request
+            dwRet = BluetoothAuthenticateDeviceEx(
+                NULL, 
+                hRadio, 
+                device_info, 
+                NULL, 
+                MITMProtectionNotRequiredBonding);
+
+            if (dwRet == ERROR_NO_MORE_ITEMS)
+            {
+                WINPAIR_DEBUG("Already paired.");
+                ret= 0;
+            }
+            else if (dwRet == ERROR_CANCELLED)
+            {
+                WINPAIR_DEBUG("User canceled the authentication.");
+                ret= 1;
+            }
+            else if (dwRet == ERROR_INVALID_PARAMETER)
+            {
+                WINPAIR_DEBUG("Invalid parameter!");
+                ret= 1;
+            }
+            else
+            {
+                // Block on authentication completing
+                WaitForSingleObject(callbackState.hAuthenticationCompleteEvent, INFINITE);
+
+                if (device_info->fAuthenticated)
+                {
+                    WINPAIR_DEBUG("Successfully paired.");
+                    ret= 0;
+                }
+                else
+                {
+                    WINPAIR_DEBUG("Failed to authenticate!");
+                    ret= 1;
+                }
+            }
+
+            if (callbackState.hAuthenticationCompleteEvent != INVALID_HANDLE_VALUE)
+            {
+                CloseHandle(callbackState.hAuthenticationCompleteEvent);
+            }
+        }
+        else
+        {
+            WINPAIR_DEBUG("BluetoothRegisterForAuthenticationEx failed!");
+            ret= 1;
+        }
+
+        if (hRegHandle != 0)
+        {
+            BluetoothUnregisterAuthentication(hRegHandle);
+            hRegHandle= 0;
+        }
+    }
+    else
+    {
+        WINPAIR_DEBUG("Already authenticated.");
+        ret= 0;
+    }
+
+    return ret;
+}
 
 static int
 patch_registry(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS *radio_addr)
@@ -368,7 +525,7 @@ is_windows8_or_later()
 
 
 static void
-handle_windows8_and_later(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio)
+handle_windows8_and_later(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio, enum PSMove_Model_Type model)
 {
     unsigned int scan = 0;
     int connected = 0;
@@ -379,6 +536,16 @@ handle_windows8_and_later(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_AD
         } else {
             if (is_move_motion_controller(&device_info)) {
                 WINPAIR_DEBUG("Found Move Motion Controller matching the given address");
+
+                if (model == Model_ZCM2)
+                {
+                    if (authenticate_controller(hRadio, &device_info) != 0)
+                    {
+                        WINPAIR_DEBUG("Failed to authenticate the controller");
+                        Sleep(SLEEP_BETWEEN_SCANS);
+                        continue;
+                    }
+                }
 
                 unsigned int conn_try;
                 for (conn_try = 1; conn_try <= CONN_RETRIES; conn_try++) {
@@ -441,7 +608,7 @@ handle_windows8_and_later(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_AD
 
 
 static void
-handle_windows_pre8(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio)
+handle_windows_pre8(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio, enum PSMove_Model_Type model)
 {
     int connected = 0;
     while (!connected) {
@@ -451,6 +618,16 @@ handle_windows_pre8(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS 
         } else {
             if (is_move_motion_controller(&device_info)) {
                 WINPAIR_DEBUG("Found Move Motion Controller matching the given address");
+
+                if (model == Model_ZCM2)
+                {
+                    if (authenticate_controller(hRadio, &device_info) != 0)
+                    {
+                        WINPAIR_DEBUG("Failed to authenticate the controller");
+                        Sleep(SLEEP_BETWEEN_SCANS);
+                        continue;
+                    }
+                }
 
                 if (device_info.fConnected) {
                     /* enable HID service only if necessary */
@@ -483,7 +660,7 @@ handle_windows_pre8(const BLUETOOTH_ADDRESS *move_addr, const BLUETOOTH_ADDRESS 
 
 
 static int
-windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio)
+windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radio_addr, const HANDLE hRadio, enum PSMove_Model_Type model)
 {
     /* parse controller's Bluetooth device address string */
     BLUETOOTH_ADDRESS *move_addr = string_to_btaddr(move_addr_str);
@@ -512,10 +689,10 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
 
     if (is_windows8_or_later()) {
         WINPAIR_DEBUG("Dealing with Windows 8 or later");
-        handle_windows8_and_later(move_addr, radio_addr, hRadio);
+        handle_windows8_and_later(move_addr, radio_addr, hRadio, model);
     } else {
         WINPAIR_DEBUG("Dealing with Windows version older than 8");
-        handle_windows_pre8(move_addr, radio_addr, hRadio);
+        handle_windows_pre8(move_addr, radio_addr, hRadio, model);
     }
 
     free(move_addr);
@@ -688,7 +865,7 @@ psmove_port_register_psmove(const char *addr, const char *host, enum PSMove_Mode
         return PSMove_False;
     }
 
-    int res = windows_register_psmove(addr, &radioInfo.address, hRadio);
+    int res = windows_register_psmove(addr, &radioInfo.address, hRadio, model);
     CloseHandle(hRadio);
 
     return (res == 0) ? PSMove_True : PSMove_False;

--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -48,7 +48,7 @@ enum _PSMoveCalibrationFlag {
 struct _PSMoveCalibration {
     PSMove *move;
 
-    char usb_calibration[PSMOVE_CALIBRATION_BLOB_SIZE];
+    char usb_calibration[PSMOVE_MAX_CALIBRATION_BLOB_SIZE];
     int flags;
 
     char *filename;
@@ -69,6 +69,9 @@ struct _PSMoveCalibration {
 
     /* Pre-calculated factors for gyroscope mapping */
     float gx, gy, gz;
+
+    /* Pre-calculated raw drift values for gyroscope mapping */
+    int dx, dy, dz;
 };
 
 
@@ -108,11 +111,19 @@ psmove_calibration_save(PSMoveCalibration *calibration);
 
 
 int
-psmove_calibration_decode(char *data, int offset)
+psmove_calibration_decode_16bit_unsigned(char *data, int offset)
 {
     unsigned char low = data[offset] & 0xFF;
     unsigned char high = (data[offset+1]) & 0xFF;
     return (low | (high << 8)) - 0x8000;
+}
+
+short
+psmove_calibration_decode_16bit_signed(char *data, int offset)
+{
+    unsigned short low = data[offset] & 0xFF;
+    unsigned short high = (data[offset+1]) & 0xFF;
+    return (short)(low | (high << 8));
 }
 
 unsigned int
@@ -135,7 +146,7 @@ psmove_calibration_decode_float(char *data, int offset)
 
 
 void
-psmove_calibration_parse_usb(PSMoveCalibration *calibration)
+psmove_ZCM1_calibration_parse_usb(PSMoveCalibration *calibration)
 {
     assert(calibration != NULL);
     char *data = calibration->usb_calibration;
@@ -150,9 +161,9 @@ psmove_calibration_parse_usb(PSMoveCalibration *calibration)
     t = psmove_calibration_decode_12bits(data, 0x02);
     printf("# Temperature: 0x%04X (%.0f °C)\n", t, _psmove_temperature_to_celsius(t));
     for (orientation=0; orientation<6; orientation++) {
-        x = psmove_calibration_decode(data, 0x04 + 6*orientation);
-        y = psmove_calibration_decode(data, 0x04 + 6*orientation + 2);
-        z = psmove_calibration_decode(data, 0x04 + 6*orientation + 4);
+        x = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation);
+        y = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 2);
+        z = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 4);
         printf("# Orientation #%d:      (%5d | %5d | %5d)\n", orientation, x, y, z);
     }
 
@@ -161,27 +172,27 @@ psmove_calibration_parse_usb(PSMoveCalibration *calibration)
     t = psmove_calibration_decode_12bits(data, 0x42);
     printf("# Temperature: 0x%04X (%.0f °C)\n", t, _psmove_temperature_to_celsius(t));
     for (orientation=0; orientation<3; orientation++) {
-        x = psmove_calibration_decode(data, 0x46 + 8*orientation);
-        y = psmove_calibration_decode(data, 0x46 + 8*orientation + 2);
-        z = psmove_calibration_decode(data, 0x46 + 8*orientation + 4);
+        x = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation);
+        y = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation + 2);
+        z = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation + 4);
         printf("# Gyro %c, 80 rpm:      (%5d | %5d | %5d)\n", "XYZ"[orientation], x, y, z);
     }
 
     printf("\n");
 
     t = psmove_calibration_decode_12bits(data, 0x28);
-    x = psmove_calibration_decode(data, 0x2a);
-    y = psmove_calibration_decode(data, 0x2a + 2);
-    z = psmove_calibration_decode(data, 0x2a + 4);
+    x = psmove_calibration_decode_16bit_unsigned(data, 0x2a);
+    y = psmove_calibration_decode_16bit_unsigned(data, 0x2a + 2);
+    z = psmove_calibration_decode_16bit_unsigned(data, 0x2a + 4);
     printf("# Temperature: 0x%04X (%.0f °C)\n", t, _psmove_temperature_to_celsius(t));
     printf("# Gyro, 0 rpm (@0x2a): (%5d | %5d | %5d)\n", x, y, z);
 
     printf("\n");
 
     t = psmove_calibration_decode_12bits(data, 0x30);
-    x = psmove_calibration_decode(data, 0x32);
-    y = psmove_calibration_decode(data, 0x32 + 2);
-    z = psmove_calibration_decode(data, 0x32 + 4);
+    x = psmove_calibration_decode_16bit_unsigned(data, 0x32);
+    y = psmove_calibration_decode_16bit_unsigned(data, 0x32 + 2);
+    z = psmove_calibration_decode_16bit_unsigned(data, 0x32 + 4);
     printf("# Temperature: 0x%04X (%.0f °C)\n", t, _psmove_temperature_to_celsius(t));
     printf("# Gyro, 0 rpm (@0x32): (%5d | %5d | %5d)\n", x, y, z);
 
@@ -207,6 +218,42 @@ psmove_calibration_parse_usb(PSMoveCalibration *calibration)
 }
 
 void
+psmove_ZCM2_calibration_parse_usb(PSMoveCalibration *calibration)
+{
+    assert(calibration != NULL);
+    char *data = calibration->usb_calibration;
+    int orientation;
+    int x, y, z;
+
+    printf("\n");
+
+    /* https://github.com/nitsch/moveonpc/wiki/Calibration-data-CECH%E2%80%90ZCM2 */
+
+    for (orientation=0; orientation<6; orientation++) {
+        x = psmove_calibration_decode_16bit_signed(data, 0x04 + 6*orientation);
+        y = psmove_calibration_decode_16bit_signed(data, 0x04 + 6*orientation + 2);
+        z = psmove_calibration_decode_16bit_signed(data, 0x04 + 6*orientation + 4);
+        printf("# Orientation #%d:      (%5d | %5d | %5d)\n", orientation, x, y, z);
+    }
+
+    printf("\n");
+
+    x = psmove_calibration_decode_16bit_signed(data, 0x26);
+    y = psmove_calibration_decode_16bit_signed(data, 0x26 + 2);
+    z = psmove_calibration_decode_16bit_signed(data, 0x26 + 4);
+    printf("# Gyro Bias?, 0 rpm (@0x26): (%5d | %5d | %5d)\n", x, y, z);
+
+	printf("\n");
+
+    for (orientation=0; orientation<6; orientation++) {
+        x = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation);
+        y = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 2);
+        z = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 4);
+        printf("# Gyro %c, 90 rpm:      (%5d | %5d | %5d)\n", "XYZXYZ"[orientation], x, y, z);
+    }
+}
+
+void
 psmove_calibration_get_usb_accel_values(PSMoveCalibration *calibration,
         int *x1, int *x2, int *y1, int *y2, int *z1, int *z2)
 {
@@ -216,45 +263,100 @@ psmove_calibration_get_usb_accel_values(PSMoveCalibration *calibration,
 
     int orientation;
 
-    /* Minimum (negative) value of each axis */
-    orientation = 1;
-    *x1 = psmove_calibration_decode(data, 0x04 + 6*orientation);
-    orientation = 5;
-    *y1 = psmove_calibration_decode(data, 0x04 + 6*orientation + 2);
-    orientation = 2;
-    *z1 = psmove_calibration_decode(data, 0x04 + 6*orientation + 4);
+	enum PSMove_Model_Type model_type= psmove_get_model(calibration->move);
 
-    /* Maximum (positive) values of each axis */
-    orientation = 3;
-    *x2 = psmove_calibration_decode(data, 0x04 + 6*orientation);
-    orientation = 4;
-    *y2 = psmove_calibration_decode(data, 0x04 + 6*orientation + 2);
-    orientation = 0;
-    *z2 = psmove_calibration_decode(data, 0x04 + 6*orientation + 4);
+	if (model_type == Model_ZCM1)
+	{
+		/* Minimum (negative) value of each axis */
+		orientation = 1;
+		*x1 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation);
+		orientation = 5;
+		*y1 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 2);
+		orientation = 2;
+		*z1 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 4);
+
+		/* Maximum (positive) values of each axis */
+		orientation = 3;
+		*x2 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation);
+		orientation = 4;
+		*y2 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 2);
+		orientation = 0;
+		*z2 = psmove_calibration_decode_16bit_unsigned(data, 0x04 + 6*orientation + 4);
+	}
+	else if (model_type == Model_ZCM2)
+	{
+		/* Minimum (negative) value of each axis */
+		orientation = 1;
+		*x1 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation);
+		orientation = 3;
+		*y1 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation + 2);
+		orientation = 5;
+		*z1 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation + 4);
+
+		/* Maximum (positive) values of each axis */
+		orientation = 0;
+		*x2 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation);
+		orientation = 2;
+		*y2 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation + 2);
+		orientation = 4;
+		*z2 = psmove_calibration_decode_16bit_signed(data, 0x02 + 6*orientation + 4);
+	}
 }
 
 
 void
-psmove_calibration_get_usb_gyro_values(PSMoveCalibration *calibration,
+psmove_calibration_get_zcm1_usb_gyro_values(PSMoveCalibration *calibration,
         int *x, int *y, int *z)
 {
     assert(calibration != NULL);
     assert(psmove_calibration_supported(calibration));
     char *data = calibration->usb_calibration;
 
-    int bx, by, bz; /* Bias(?) values, need to sustract those */
-    bx = psmove_calibration_decode(data, 0x2a);
-    by = psmove_calibration_decode(data, 0x2a + 2);
-    bz = psmove_calibration_decode(data, 0x2a + 4);
+    int bx, by, bz; /* Bias(?) values, need to subtract those */
+    bx = psmove_calibration_decode_16bit_unsigned(data, 0x2a);
+    by = psmove_calibration_decode_16bit_unsigned(data, 0x2a + 2);
+    bz = psmove_calibration_decode_16bit_unsigned(data, 0x2a + 4);
 
     int orientation;
 
     orientation = 0;
-    *x = psmove_calibration_decode(data, 0x46 + 8*orientation) - bx;
+    *x = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation) - bx;
     orientation = 1;
-    *y = psmove_calibration_decode(data, 0x46 + 8*orientation + 2) - by;
+    *y = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation + 2) - by;
     orientation = 2;
-    *z = psmove_calibration_decode(data, 0x46 + 8*orientation + 4) - bz;
+    *z = psmove_calibration_decode_16bit_unsigned(data, 0x46 + 8*orientation + 4) - bz;
+}
+
+void
+psmove_calibration_get_zcm2_usb_gyro_values(PSMoveCalibration *calibration,
+        int *x1, int *x2, int *y1, int *y2, int *z1, int *z2,
+		int *dx, int *dy, int *dz)
+{
+    assert(calibration != NULL);
+    assert(psmove_calibration_supported(calibration));
+    char *data = calibration->usb_calibration;
+
+    int orientation;
+
+	/* Minimum (negative) value of each axis */
+	orientation = 3;
+	*x1 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation);
+	orientation = 4;
+	*y1 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 2);
+	orientation = 5;
+	*z1 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 4);
+
+	/* Maximum (positive) values of each axis */
+	orientation = 0;
+	*x2 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation);
+	orientation = 1;
+	*y2 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 2);
+	orientation = 2;
+	*z2 = psmove_calibration_decode_16bit_signed(data, 0x30 + 6*orientation + 4);
+
+    *dx = psmove_calibration_decode_16bit_signed(data, 0x26);
+    *dy = psmove_calibration_decode_16bit_signed(data, 0x26 + 2);
+    *dz = psmove_calibration_decode_16bit_signed(data, 0x26 + 4);
 }
 
 void
@@ -264,7 +366,13 @@ psmove_calibration_dump_usb(PSMoveCalibration *calibration)
 
     assert(calibration != NULL);
 
-    for (j=0; j<sizeof(calibration->usb_calibration); j++) {
+	enum PSMove_Model_Type model= psmove_get_model(calibration->move);
+	size_t calibration_blob_size= 
+		(model == Model_ZCM1) 
+		? PSMOVE_ZCM1_CALIBRATION_BLOB_SIZE 
+		: PSMOVE_ZCM2_CALIBRATION_BLOB_SIZE;
+
+    for (j=0; j<calibration_blob_size; j++) {
         printf("%02x", (unsigned char) calibration->usb_calibration[j]);
         if (j % 16 == 15) {
             printf("\n");
@@ -274,7 +382,10 @@ psmove_calibration_dump_usb(PSMoveCalibration *calibration)
     }
     printf("\n");
 
-    psmove_calibration_parse_usb(calibration);
+	if (model == Model_ZCM1) 
+		psmove_ZCM1_calibration_parse_usb(calibration);
+	else if (model == Model_ZCM2)
+		psmove_ZCM2_calibration_parse_usb(calibration);
     printf("\n");
 }
 
@@ -286,6 +397,8 @@ psmove_calibration_new(PSMove *move)
     PSMove_Data_BTAddr addr;
     char *serial;
     int i;
+
+	enum PSMove_Model_Type model= psmove_get_model(move);
 
     PSMoveCalibration *calibration =
         (PSMoveCalibration*)calloc(1, sizeof(PSMoveCalibration));
@@ -341,7 +454,7 @@ psmove_calibration_new(PSMove *move)
 
         /**
          *
-         * Calculation of accelermeter mapping (as factor of gravity, 1g):
+         * Calculation of accelerometer mapping (as factor of gravity, 1g):
          *
          *                2 * (raw - low)
          *  calibrated = ----------------  - 1
@@ -393,20 +506,20 @@ psmove_calibration_new(PSMove *move)
          * with:
          *
          *  raw ..... Raw sensor reading
-         *  rpm80 ... Sensor reading at 80 RPM (from calibration blob)
+         *  rpmXX ... Sensor reading at XX RPM (from calibration blob)
          *  rpm60 ... Sensor reading at 60 RPM (1 rotation per second)
          *
          * Or combined:
          *
-         *                80 * raw * 2 PI
+         *                XX * raw * 2 PI
          *  calibrated = -----------------
-         *                  60 * rpm80
+         *                  60 * rpmXX
          *
          * Now define:
          *
-         *       2 * PI * 80
+         *       2 * PI * XX
          *  f = -------------
-         *        60 * rpm80
+         *        60 * rpmXX
          *
          * Then we get:
          *
@@ -414,14 +527,52 @@ psmove_calibration_new(PSMove *move)
          *
          **/
 
-        int gx80, gy80, gz80;
-        psmove_calibration_get_usb_gyro_values(calibration,
-                &gx80, &gy80, &gz80);
+		const float k_rpm_to_rad_per_sec = (2.0f * (float)M_PI) / 60.0f;
 
-        float factor = (float)(2.f * M_PI * 80.f) / 60.f;
-        calibration->gx = factor / (float)gx80;
-        calibration->gy = factor / (float)gy80;
-        calibration->gz = factor / (float)gz80;
+		if (model == Model_ZCM1)
+		{
+			/* ZCM1 gyro calibrations are at +80RPM */
+			int gx80, gy80, gz80;
+			psmove_calibration_get_zcm1_usb_gyro_values(calibration,
+					&gx80, &gy80, &gz80);
+
+			const float k_calibration_rpm= 80.f;
+			const float factor = k_calibration_rpm * k_rpm_to_rad_per_sec;
+
+			calibration->gx = factor / (float)gx80;
+			calibration->gy = factor / (float)gy80;
+			calibration->gz = factor / (float)gz80;
+
+			// Per frame drift taken into account using adjusted gain values
+			calibration->dx = 0;
+			calibration->dy = 0;
+			calibration->dz = 0;
+		} else {
+			/* ZCM1 gyro calibrations are at +90RPM and -90RPM 
+
+			   Note on the bias values (dx, dy, and dz).
+			   Given the slightly asymmetrical min and max 90RPM readings you might think
+			   that there is a bias in the gyros that you should compute by finding
+			   the y-intercept value (the y-intercept of the gyro reading/angular speed line) 
+			   using the formula b= y_hi - m*x_hi, but this results in pretty bad
+			   controller drift. We get much better results ignoring the y-intercept
+			   and instead use the presumed "drift" values stored at 0x26
+			*/
+			int gx90_low, gx90_high, gy90_low, gy90_high, gz90_low, gz90_high;
+			psmove_calibration_get_zcm2_usb_gyro_values(calibration,
+					&gx90_low, &gx90_high, &gy90_low, &gy90_high, &gz90_low, &gz90_high,
+					&calibration->dx, &calibration->dy, &calibration->dz);
+
+			const float k_calibration_rpm= 90.f;
+			const float calibration_hi= k_calibration_rpm * k_rpm_to_rad_per_sec;
+			const float calibration_low= -k_calibration_rpm * k_rpm_to_rad_per_sec;
+			const float factor = calibration_hi - calibration_low;
+
+			// Compute the gain value (the slope of the gyro reading/angular speed line)
+			calibration->gx = factor / (float)(gx90_high - gx90_low);
+			calibration->gy = factor / (float)(gy90_high - gy90_low);
+			calibration->gz = factor / (float)(gz90_high - gz90_low);
+		}
     } else {
         /* No calibration data - pass-through input data */
         calibration->ax = 1.f;
@@ -435,6 +586,10 @@ psmove_calibration_new(PSMove *move)
         calibration->gx = 1.f;
         calibration->gy = 1.f;
         calibration->gz = 1.f;
+
+        calibration->dx = 0;
+        calibration->dy = 0;
+        calibration->dz = 0;
     }
 
     return calibration;
@@ -448,13 +603,27 @@ psmove_calibration_read_from_usb(PSMoveCalibration *calibration)
     char *data;
     size_t size;
 
-    if (_psmove_get_calibration_blob(calibration->move, &data, &size)) {
-        assert(size == PSMOVE_CALIBRATION_BLOB_SIZE);
-        memcpy(calibration->usb_calibration, data, size);
-        free(data);
-        calibration->flags |= CalibrationFlag_HaveUSB;
-        return 1;
-    }
+	enum PSMove_Model_Type model= psmove_get_model(calibration->move);
+	if (model == Model_ZCM1)
+	{
+		if (_psmove_get_zcm1_calibration_blob(calibration->move, &data, &size) == 1) {
+			assert(size == PSMOVE_ZCM1_CALIBRATION_BLOB_SIZE);
+			memcpy(calibration->usb_calibration, data, size);
+			free(data);
+			calibration->flags |= CalibrationFlag_HaveUSB;
+			return 1;
+		}
+	}
+	else if (model == Model_ZCM2)
+	{
+		if (_psmove_get_zcm2_calibration_blob(calibration->move, &data, &size) == 1) {
+			assert(size == PSMOVE_ZCM2_CALIBRATION_BLOB_SIZE);
+			memcpy(calibration->usb_calibration, data, size);
+			free(data);
+			calibration->flags |= CalibrationFlag_HaveUSB;
+			return 1;
+		}
+	}
 
     return 0;
 }
@@ -500,15 +669,15 @@ psmove_calibration_map_gyroscope(PSMoveCalibration *calibration,
     psmove_return_if_fail(raw_input != NULL);
 
     if (gx) {
-        *gx = (float)raw_input[0] * calibration->gx;
+        *gx = (float)(raw_input[0] - calibration->dx) * calibration->gx;
     }
 
     if (gy) {
-        *gy = (float)raw_input[1] * calibration->gy;
+        *gy = (float)(raw_input[1] - calibration->dy) * calibration->gy;
     }
 
     if (gz) {
-        *gz = (float)raw_input[2] * calibration->gz;
+        *gz = (float)(raw_input[2] - calibration->dz) * calibration->gz;
     }
 }
 

--- a/src/psmove_orientation.cpp
+++ b/src/psmove_orientation.cpp
@@ -162,8 +162,16 @@ psmove_orientation_new(PSMove *move)
     orientation_state->quaternion = *k_psmove_quaternion_identity;
     orientation_state->reset_quaternion = *k_psmove_quaternion_identity;
 
-    /* Initialize data specific to the selected filter */
-    psmove_orientation_set_fusion_type(orientation_state, OrientationFusion_ComplementaryMARG);
+    /* Initialize data specific to the selected filter */	
+	if (psmove_get_model(move) == Model_ZCM1)
+	{
+	    psmove_orientation_set_fusion_type(orientation_state, OrientationFusion_ComplementaryMARG);
+	}
+	else
+	{
+		// No magnetometer on the ZCM2
+		psmove_orientation_set_fusion_type(orientation_state, OrientationFusion_MadgwickIMU);
+	}
 
     /* Set the transform used re-orient the calibration data used by the orientation fusion algorithm */
     psmove_orientation_set_calibration_transform(orientation_state, k_psmove_identity_pose_laying_flat);

--- a/src/psmove_private.h
+++ b/src/psmove_private.h
@@ -104,8 +104,14 @@ struct PSMove_RGBValue {
 /* Buffer size for calibration data */
 #define PSMOVE_CALIBRATION_SIZE 49
 
-/* Three blocks, minus 2x the header (2 bytes) for the 2nd and 3rd block */
-#define PSMOVE_CALIBRATION_BLOB_SIZE (PSMOVE_CALIBRATION_SIZE*3 - 2*2)
+/* Three blocks, minus header (2 bytes) for blocks 2,3 */
+#define PSMOVE_ZCM1_CALIBRATION_BLOB_SIZE	(PSMOVE_CALIBRATION_SIZE*3 - 2*2) 
+
+/* Three blocks, minus header (2 bytes) for block 2 */
+#define PSMOVE_ZCM2_CALIBRATION_BLOB_SIZE	(PSMOVE_CALIBRATION_SIZE*2 - 2*1) 
+
+/* The maximum calibration blob size */
+#define PSMOVE_MAX_CALIBRATION_BLOB_SIZE	PSMOVE_ZCM1_CALIBRATION_BLOB_SIZE
 
 /* System-wide data directory */
 #define PSMOVE_SYSTEM_DATA_DIR "/etc/psmoveapi"
@@ -139,14 +145,24 @@ ADDAPI const char *
 ADDCALL _psmove_get_device_path(PSMove *move);
 
 /**
- * [PRIVATE API] Get the calibration data from a connected USB controller.
+ * [PRIVATE API] Get the ZCM1 calibration data from a connected USB controller.
  *
  * The pointer *dest will be set to a newly-allocated byte array
  * of a certain size (which will be saved in *size) and the caller
  * has to free this field with free()
  **/
 ADDAPI int
-ADDCALL _psmove_get_calibration_blob(PSMove *move, char **dest, size_t *size);
+ADDCALL _psmove_get_zcm1_calibration_blob(PSMove *move, char **dest, size_t *size);
+
+/**
+ * [PRIVATE API] Get the ZCM2 calibration data from a connected USB controller.
+ *
+ * The pointer *dest will be set to a newly-allocated byte array
+ * of a certain size (which will be saved in *size) and the caller
+ * has to free this field with free()
+ **/
+ADDAPI int
+ADDCALL _psmove_get_zcm2_calibration_blob(PSMove *move, char **dest, size_t *size);
 
 /**
  * [PRIVATE API] Translate a raw temperature value to degrees Celsius


### PR DESCRIPTION
I've been working with @nitsch to get the new ZCM2 PSMoveController working in PSMoveService. I wanted to port the relevant subset of that work over to psmoveapi. Specifically the controller calibration parsing, input packet parsing, and controller pairing in Windows. I've done some preliminary testing on Windows to verify controller pairing and verifying that the orientation work in the test_opengl programs and also updated the calibration dumping code to show ZCM2 calibration fields we are currently interpreting. Given that this is a big enough change I would love any feedback on the implementation. 

The single biggest question I have is if you are ok with the PSMove_Data_Input getting turned into a union of two structs (PSMove_ZCM1_Data_Input and PSMove_ZCM1_Data_Input) or if you would prefer the common fields shared in PSMove_Data_Input and only the differences in the union. This would simplify some changes, but make some sizeof()s a bit more tricky.