### PR TITLE
Bugfixes

### DIFF
--- a/src/platform/psmove_port_windows.c
+++ b/src/platform/psmove_port_windows.c
@@ -788,13 +788,12 @@ psmove_port_set_socket_timeout_ms(int socket, uint32_t timeout_ms)
 void
 psmove_port_sleep_ms(uint32_t duration_ms)
 {
-    HANDLE timer = NULL;
     LARGE_INTEGER ft;
 
     // Convert to 100 nanosecond interval, negative value indicates relative time
     ft.QuadPart = -(10ll * 1000ll * (LONGLONG)duration_ms);
 
-    timer = CreateWaitableTimer(NULL, TRUE, NULL);
+	HANDLE timer = CreateWaitableTimer(NULL, TRUE, NULL);
     if (timer == NULL) {
         psmove_WARNING("In psmove_port_sleep_ms, CreateWaitableTimer failed (%d)\n", GetLastError());
         return;

--- a/src/platform/psmove_port_windows.c
+++ b/src/platform/psmove_port_windows.c
@@ -793,7 +793,7 @@ psmove_port_sleep_ms(uint32_t duration_ms)
     // Convert to 100 nanosecond interval, negative value indicates relative time
     ft.QuadPart = -(10ll * 1000ll * (LONGLONG)duration_ms);
 
-	HANDLE timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    HANDLE timer = CreateWaitableTimer(NULL, TRUE, NULL);
     if (timer == NULL) {
         psmove_WARNING("In psmove_port_sleep_ms, CreateWaitableTimer failed (%d)\n", GetLastError());
         return;

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -55,7 +55,9 @@
 #define PSMOVE_BUFFER_SIZE 9
 
 /* Buffer size for the Bluetooth address get request */
-#define PSMOVE_BTADDR_GET_SIZE 16
+#define PSMOVE_ZCM1_BTADDR_GET_SIZE 16
+#define PSMOVE_ZCM2_BTADDR_GET_SIZE 20
+#define PSMOVE_MAX_BTADDR_GET_SIZE PSMOVE_ZCM2_BTADDR_GET_SIZE
 
 /* Buffer size for the Bluetooth address set request */
 #define PSMOVE_BTADDR_SET_SIZE 23
@@ -920,7 +922,7 @@ psmove_connect()
 int
 _psmove_read_btaddrs(PSMove *move, PSMove_Data_BTAddr *host, PSMove_Data_BTAddr *controller)
 {
-    unsigned char btg[PSMOVE_BTADDR_GET_SIZE];
+    unsigned char btg[PSMOVE_MAX_BTADDR_GET_SIZE];
     int res;
 
     psmove_return_val_if_fail(move != NULL, 0);

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -55,9 +55,7 @@
 #define PSMOVE_BUFFER_SIZE 9
 
 /* Buffer size for the Bluetooth address get request */
-#define PSMOVE_ZCM1_BTADDR_GET_SIZE 16
-#define PSMOVE_ZCM2_BTADDR_GET_SIZE 20
-#define PSMOVE_MAX_BTADDR_GET_SIZE PSMOVE_ZCM2_BTADDR_GET_SIZE
+#define PSMOVE_BTADDR_GET_SIZE 16
 
 /* Buffer size for the Bluetooth address set request */
 #define PSMOVE_BTADDR_SET_SIZE 23
@@ -922,7 +920,7 @@ psmove_connect()
 int
 _psmove_read_btaddrs(PSMove *move, PSMove_Data_BTAddr *host, PSMove_Data_BTAddr *controller)
 {
-    unsigned char btg[PSMOVE_MAX_BTADDR_GET_SIZE];
+    unsigned char btg[PSMOVE_BTADDR_GET_SIZE];
     int res;
 
     psmove_return_val_if_fail(move != NULL, 0);

--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -587,6 +587,7 @@ psmove_calibration_new(PSMove *move)
                     calibration->gy = factor / (float)(gy90_high - gy90_low);
                     calibration->gz = factor / (float)(gz90_high - gz90_low);
                 }
+                break;
             default:
                 psmove_CRITICAL("Unknown PS Move model");
                 break;

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -151,11 +151,15 @@ PSMoveAPI::PSMoveAPI(EventReceiver *receiver, void *user_data)
     for (int i=0; i<n; i++) {
         PSMove *move = psmove_connect_by_id(i);
 
-        char *tmp = psmove_get_serial(move);
-        std::string serial(tmp);
-        free(tmp);
+        if (move) {
+            char *tmp = psmove_get_serial(move);
+            if (tmp) {
+                std::string serial(tmp);
+                free(tmp);
 
-        moves[serial].emplace_back(move);
+                moves[serial].emplace_back(move);
+            }
+        }
     }
 
     int i = 0;


### PR DESCRIPTION
1. `psmove_port_sleep_ms` for Windows would fail to sleep because the input parameter is `uint32_t` and would cause the operands in `ft.QuadPart = -(10 * 1000 * duration_ms)` to be promoted to unsigned which caused an overflow when applying the negative operator resulting in a large positive value assigned to `QuadPart`
2. Fixed case statement fall through in `psmove_calibration_new`
3. On Windows, `psmove_connect_by_id` will occasionally return `NULL` which causes a crash in `PSMoveAPI::PSMoveAPI` when it tries to construct a string with a `char* == NULL`