### PR TITLE
Enable sixpair on Windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(INFO_LICENSE "BSD")
 
 # Make a debug build with helpful output for debugging / maintenance
 option(PSMOVE_USE_DEBUG "Build for debugging" OFF)
+option(PSMOVE_USE_SIXPAIR "Enable Navigation Controller pairing" ON)
 
 # Debugging output
 IF(PSMOVE_USE_DEBUG)
@@ -138,7 +139,7 @@ file(GLOB PSMOVEAPI_HEADERS
 
 file (GLOB PSMOVEAPI_MATH_HEADERS
     "${CMAKE_CURRENT_LIST_DIR}/math/*.h"
-    "${CMAKE_CURRENT_LIST_DIR}/math/*.hpp"    
+    "${CMAKE_CURRENT_LIST_DIR}/math/*.hpp"
 )
 
 file (GLOB PSMOVEAPI_MATH_SRC

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -106,7 +106,6 @@ IF (PSMOVE_USE_PS3EYE_DRIVER AND (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMA
 	source_group("Source Files\\PS3EyeDriver" FILES ${PS3_EYE_SRC})
     include_directories(${ROOT_DIR}/external/PS3EYEDriver/src)
     find_package(USB1 REQUIRED)
-    include_directories(${LIBUSB_INCLUDE_DIR})
     list(APPEND PSMOVEAPI_TRACKER_REQUIRED_LIBS ${LIBUSB_LIBRARIES})
     set(INFO_USE_PS3EYE_DRIVER "Yes")
 ELSE()
@@ -147,6 +146,7 @@ if(PSMOVE_BUILD_TRACKER)
     add_library(psmoveapi_tracker SHARED
         ${PSMOVEAPI_TRACKER_SRC}
         ${PSMOVEAPI_TRACKER_PLATFORM_SRC})
+    target_include_directories(psmoveapi_tracker PRIVATE ${LIBUSB_INCLUDE_DIR})
     target_link_libraries(psmoveapi_tracker
         psmoveapi
         ${PSMOVEAPI_REQUIRED_LIBS}

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,10 +10,9 @@ target_link_libraries(psmove psmoveapi)
 set_property(TARGET psmove PROPERTY FOLDER "Utilities")
 list(APPEND PSMOVEAPI_INSTALL_TARGETS psmove)
 
-option(PSMOVE_USE_SIXPAIR "Enable Navigation Controller pairing" ON)
-
 if (WIN32)
-  set(PSMOVE_USE_SIXPAIR OFF CACHE BOOL "Disabling Navigation Controller pairing on Windows" FORCE)
+  include(${CMAKE_CURRENT_LIST_DIR}/libusb.cmake)
+  target_link_libraries(psmove ${LIBUSB_LIBRARIES})
 else()
   # sixpair needs libusb
   find_package(PkgConfig REQUIRED)

--- a/src/utils/libusb.cmake
+++ b/src/utils/libusb.cmake
@@ -1,0 +1,137 @@
+################################################################################
+# FUNCTION dl
+################################################################################
+
+function(dl url dstdir)
+    if (EXISTS "${dstdir}")
+        return()
+    endif()
+
+    message(STATUS "Downloading: " ${url})
+
+    set(fn "${CMAKE_BINARY_DIR}/x.tar.gz")
+    file(DOWNLOAD
+        "${url}"
+        "${fn}"
+        SHOW_PROGRESS
+        INACTIVITY_TIMEOUT 300 # seconds
+    )
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${dstdir}")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xz "${fn}"
+        WORKING_DIRECTORY "${dstdir}"
+        RESULT_VARIABLE __result
+    )
+    if(NOT __result EQUAL 0)
+        message(FATAL_ERROR "error ${__result}")
+    endif()
+endfunction()
+
+################################################################################
+# FUNCTION replace_in_file_once
+################################################################################
+
+# TODO: create files in BDIR
+function(replace_in_file_once f from to)
+    string(SHA1 h "${f}${from}${to}")
+    string(SUBSTRING "${h}" 0 5 h)
+
+    # cannot set this file to bdir because multiple configs use
+    # different bdirs and will do multiple replacements
+    set(h ${f}.${h})
+    set(ch ${f}.cppan.hash)
+
+    if (EXISTS ${h} AND EXISTS ${ch})
+        file(READ ${ch} h2)
+        file(READ ${f} fc)
+        string(SHA1 h3 "${fc}")
+        if ("${h2}" STREQUAL "${h3}")
+            return()
+        endif()
+    endif()
+
+    set(lock ${f}.lock)
+    file(
+        LOCK ${lock}
+        GUARD FUNCTION # CMake bug workaround https://gitlab.kitware.com/cmake/cmake/issues/16295
+        RESULT_VARIABLE lock_result
+    )
+    if (NOT ${lock_result} EQUAL 0)
+        message(FATAL_ERROR "Lock error: ${lock_result}")
+    endif()
+
+    # double check
+    if (EXISTS ${h} AND EXISTS ${ch})
+        file(READ ${ch} h2)
+        file(READ ${f} fc)
+        string(SHA1 h3 "${fc}")
+        if ("${h2}" STREQUAL "${h3}")
+            return()
+        endif()
+    endif()
+
+    file(READ ${f} fc)
+    string(REPLACE "${from}" "${to}" fc "${fc}")
+    string(SHA1 h2 "${fc}")
+    file(WRITE "${f}" "${fc}")
+
+    # create flag file
+    file(WRITE ${h} "")
+    file(WRITE ${ch} "${h2}")
+endfunction(replace_in_file_once)
+
+################################################################################
+# dirent
+################################################################################
+
+dl(
+    "https://github.com/tronkko/dirent/archive/1.23.2.tar.gz"
+    "${CMAKE_BINARY_DIR}/dl/dirent"
+)
+set(dir "${CMAKE_BINARY_DIR}/dl/dirent/dirent-1.23.2")
+
+add_library(dirent INTERFACE)
+target_include_directories(dirent INTERFACE "${dir}/include")
+
+################################################################################
+# usb
+################################################################################
+
+dl(
+    "https://github.com/libusb/libusb/archive/v1.0.23.tar.gz"
+    "${CMAKE_BINARY_DIR}/dl/usb"
+)
+set(dir "${CMAKE_BINARY_DIR}/dl/usb/libusb-1.0.23")
+
+add_library(usb STATIC)
+file(GLOB files1 "${dir}/libusb/*.c")
+file(GLOB files2 "${dir}/libusb/os/*windows*")
+target_sources(usb PRIVATE ${files1} ${files2})
+target_include_directories(usb PUBLIC "${dir}/libusb")
+target_include_directories(usb PUBLIC "${dir}/msvc")
+file(REMOVE "${dir}/msvc/errno.h")
+
+################################################################################
+# usbcompat
+################################################################################
+
+dl(
+    "https://github.com/libusb/libusb-compat-0.1/archive/v0.1.7.tar.gz"
+    "${CMAKE_BINARY_DIR}/dl/usbcompat"
+)
+set(dir "${CMAKE_BINARY_DIR}/dl/usbcompat/libusb-compat-0.1-0.1.7")
+
+add_library(usbcompat STATIC)
+target_sources(usbcompat PRIVATE "${dir}/libusb/core.c")
+target_compile_definitions(usbcompat PRIVATE API_EXPORTED=)
+target_include_directories(usbcompat PUBLIC "${dir}/libusb")
+target_link_libraries(usbcompat usb dirent)
+if (NOT EXISTS "${dir}/libusb/unistd.h")
+    file(WRITE "${dir}/libusb/unistd.h" "")
+endif()
+replace_in_file_once("${dir}/libusb/core.c" "fmt..." "fmt, ...")
+replace_in_file_once("${dir}/libusb/core.c" "__attribute__ ((constructor))" "")
+replace_in_file_once("${dir}/libusb/core.c" "__attribute__ ((destructor))" "")
+
+set(LIBUSB_LIBRARIES usbcompat)
+
+################################################################################


### PR DESCRIPTION
Hi,

This PR enables sixpair build on Windows.
It
1) downloads dependencies (dirent, libusb, libusbcompat),
2) builds them and
3) links them to psmove target.

The problem is that current code works with libusb driver (from older windows versions or something like that). Libusb can be installed on windows using https://zadig.akeo.ie/
But with it, move controller cannot be used with bluetooth.

Default windows 10 driver is HIDUSB. With it sixpair.c code does not work and I'm not sure if it possible to make it work.

See following links describing the problem:
https://wiibrew.org/wiki/Sixaxis
> However, the SIXAXIS will not transmit any data until a special HID feature report is read, but Windows HID functions do not allow that feature report to be read due to the incorrect HID descriptor.

Also see https://twitter.com/NefariusMaximus/status/770517683875876864

@thp 
What do you think about it? Is it possible to make sixpair work via HIDUSB driver?
Anyways, please review the PR.