### PR TITLE
Fix freeing of internally allocated memory

### DIFF
--- a/examples/c/example.c
+++ b/examples/c/example.c
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
 
     char *serial = psmove_get_serial(move);
     printf("Serial: %s\n", serial);
-    free(serial);
+    psmove_free_mem(serial);
 
     ctype = psmove_connection_type(move);
     switch (ctype) {

--- a/include/psmove.h
+++ b/include/psmove.h
@@ -425,8 +425,9 @@ ADDCALL psmove_is_remote(PSMove *move);
  *
  * \param move A valid \ref PSMove handle
  *
- * \return The serial number of the controller. The caller must
- *         free() the result when it is not needed anymore.
+ * \return The serial number of the controller. The caller must free
+ *         the result using \ref psmove_free_mem() when it is not
+ *         needed anymore.
  **/
 ADDAPI char *
 ADDCALL psmove_get_serial(PSMove *move);
@@ -1529,8 +1530,9 @@ ADDCALL psmove_util_get_data_dir();
  *
  * \param filename The basename of the file (e.g. \c myfile.txt)
  *
- * \return The absolute filename to the file. The caller must
- *         free() the result when it is not needed anymore.
+ * \return The absolute filename to the file. The caller must free
+ *         the result using \ref psmove_free_mem() when it is not
+ *         needed anymore.
  * \return On error, \c NULL is returned.
  **/
 ADDAPI char *
@@ -1546,8 +1548,9 @@ ADDCALL psmove_util_get_file_path(const char *filename);
  *
  * \param filename The basename of the file (e.g. \c myfile.txt)
  *
- * \return The absolute filename to the file. The caller must
- *         free() the result when it is not needed anymore.
+ * \return The absolute filename to the file. The caller must free
+ *         the result using \ref psmove_free_mem() when it is not
+ *         needed anymore.
  * \return On error, \c NULL is returned.
  **/
 ADDAPI char *
@@ -1576,8 +1579,8 @@ ADDCALL psmove_util_get_env_int(const char *name);
  * \param name The name of the environment variable
  *
  * \return The string value of the environment variable, or NULL if the
- *         variable is not set. The caller must free() the result when
- *         it is not needed anymore.
+ *         variable is not set. The caller must free the result using
+ *         \ref psmove_free_mem() when it is not needed anymore.
  **/
 ADDAPI char *
 ADDCALL psmove_util_get_env_string(const char *name);
@@ -1589,6 +1592,15 @@ ADDCALL psmove_util_get_env_string(const char *name);
  **/
 ADDAPI void
 ADDCALL psmove_util_sleep_ms(uint32_t ms);
+
+/**
+ * \brief Free memory allocated by psmoveapi
+ *
+ * \param buf Pointer to the memory that was previously allocated and
+ *            returned by the library
+ **/
+ADDAPI void
+ADDCALL psmove_free_mem(char *buf);
 
 
 #ifdef __cplusplus

--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -253,7 +253,7 @@ moved_server::handle_request()
                     printf("Cannot convert serial\n");
                     return;
                 }
-                free(serial);
+                psmove_free_mem(serial);
             } else {
                 printf("Cannot read from device %d.\n", request.header.controller_id);
                 return;
@@ -266,7 +266,7 @@ moved_server::handle_request()
                     printf("Cannot convert serial\n");
                     return;
                 }
-                free(serial);
+                psmove_free_mem(serial);
             }
             break;
         case MOVED_REQ_REGISTER_CONTROLLER:
@@ -279,8 +279,8 @@ moved_server::handle_request()
                     printf("Could not register PS Move Controller in the system.\n");
                 }
 
-                free(addr);
-                free(host);
+                psmove_free_mem(addr);
+                psmove_free_mem(host);
             }
             break;
         case MOVED_REQ_DISCOVER:
@@ -358,7 +358,7 @@ move_daemon::dump_devices()
     for (psmove_dev *dev: devs) {
         char *serial = psmove_get_serial(dev->move);
         printf("Device %d: %s\n", dev->assigned_id, serial);
-        free(serial);
+        psmove_free_mem(serial);
     }
 #endif
     fflush(stdout);

--- a/src/daemon/moved_client.cpp
+++ b/src/daemon/moved_client.cpp
@@ -126,7 +126,7 @@ moved_client_list_discover(moved_client_list *result)
         if (moved_client_send(client, MOVED_REQ_GET_HOST_BTADDR, 0, nullptr, 0)) {
             char *serial = _psmove_btaddr_to_string(*((PSMove_Data_BTAddr *)client->response_buf.get_host_btaddr.btaddr));
             printf("Bluetooth host address of '%s' is '%s'\n", hostname, serial);
-            free(serial);
+            psmove_free_mem(serial);
         }
     }
     return result;
@@ -162,7 +162,7 @@ moved_client_list_open()
         }
         fclose(fp);
     }
-    free(filename);
+    psmove_free_mem(filename);
 
     /* XXX: Read from config file */
     //result = moved_client_list_insert(result, moved_client_create("localhost"));

--- a/src/platform/psmove_port_windows.c
+++ b/src/platform/psmove_port_windows.c
@@ -683,7 +683,7 @@ windows_register_psmove(const char *move_addr_str, const BLUETOOTH_ADDRESS *radi
         handle_windows_pre8(move_addr, radio_addr, hRadio, model);
     }
 
-    free(move_addr);
+    psmove_free_mem(move_addr);
 
     return 0;
 }

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -2590,3 +2590,12 @@ psmove_util_sleep_ms(uint32_t ms)
 {
     psmove_port_sleep_ms(ms);
 }
+
+void
+psmove_free_mem(char *buf)
+{
+    if (buf) {
+        free(buf);
+    }
+}
+

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -967,7 +967,7 @@ _psmove_read_btaddrs(PSMove *move, PSMove_Data_BTAddr *host, PSMove_Data_BTAddr 
 
         char *current_host = _psmove_btaddr_to_string(btg+10);
         psmove_DEBUG("Current host: %s\n", current_host);
-        free(current_host);
+        psmove_free_mem(current_host);
 
         if (host != NULL) {
             memcpy(*host, btg+10, 6);
@@ -1174,8 +1174,8 @@ psmove_pair(PSMove *move)
 
     enum PSMove_Bool result = psmove_port_register_psmove(addr, host, move->model);
 
-    free(addr);
-    free(host);
+    psmove_free_mem(addr);
+    psmove_free_mem(host);
 
     return result;
 }
@@ -1197,7 +1197,7 @@ psmove_host_pair_custom_model(const char *addr, enum PSMove_Model_Type model)
 
     enum PSMove_Bool result = psmove_port_register_psmove(addr, host, model);
 
-    free(host);
+    psmove_free_mem(host);
 
     return result;
 }
@@ -1231,8 +1231,8 @@ psmove_pair_custom(PSMove *move, const char *new_host_string)
 
     enum PSMove_Bool result = psmove_port_register_psmove(addr, host, move->model);
 
-    free(addr);
-    free(host);
+    psmove_free_mem(addr);
+    psmove_free_mem(host);
 
     return result;
 }
@@ -2140,7 +2140,7 @@ psmove_get_magnetometer_calibration_filename(PSMove *move)
         }
     }
     snprintf(filename, PATH_MAX, "%s.magnetometer.csv", serial);
-    free(serial);
+    psmove_free_mem(serial);
 
     char *filepath = psmove_util_get_file_path(filename);
     return filepath;
@@ -2152,7 +2152,7 @@ psmove_save_magnetometer_calibration(PSMove *move)
     psmove_return_if_fail(move != NULL);
     char *filename = psmove_get_magnetometer_calibration_filename(move);
     FILE *fp = fopen(filename, "w");
-    free(filename);
+    psmove_free_mem(filename);
     psmove_return_if_fail(fp != NULL);
 
 	fprintf(fp, "mx,my,mz\n");
@@ -2180,12 +2180,12 @@ psmove_load_magnetometer_calibration(PSMove *move)
     psmove_reset_magnetometer_calibration(move);
     char *filename = psmove_get_magnetometer_calibration_filename(move);
     FILE *fp = fopen(filename, "r");
-    free(filename);
+    psmove_free_mem(filename);
 
 	if (fp == NULL) {
         char *addr = psmove_get_serial(move);
         psmove_WARNING("Magnetometer in %s not yet calibrated.\n", addr);
-        free(addr);
+        psmove_free_mem(addr);
 		goto finish;
     }
 

--- a/src/psmove_calibration.c
+++ b/src/psmove_calibration.c
@@ -443,7 +443,7 @@ psmove_calibration_new(PSMove *move)
     calibration->system_filename = psmove_util_get_system_file_path(template);
 
     free(template);
-    free(serial);
+    psmove_free_mem(serial);
 
     /* Try to load the calibration data from disk, or from USB */
     psmove_calibration_load(calibration);
@@ -627,7 +627,7 @@ psmove_calibration_read_from_usb(PSMoveCalibration *calibration)
             if (_psmove_get_zcm1_calibration_blob(calibration->move, &data, &size) == 1) {
                 assert(size == PSMOVE_ZCM1_CALIBRATION_BLOB_SIZE);
                 memcpy(calibration->usb_calibration, data, size);
-                free(data);
+                psmove_free_mem(data);
                 calibration->flags |= CalibrationFlag_HaveUSB;
                 return 1;
             }
@@ -636,7 +636,7 @@ psmove_calibration_read_from_usb(PSMoveCalibration *calibration)
             if (_psmove_get_zcm2_calibration_blob(calibration->move, &data, &size) == 1) {
                 assert(size == PSMOVE_ZCM2_CALIBRATION_BLOB_SIZE);
                 memcpy(calibration->usb_calibration, data, size);
-                free(data);
+                psmove_free_mem(data);
                 calibration->flags |= CalibrationFlag_HaveUSB;
                 return 1;
             }
@@ -782,8 +782,8 @@ psmove_calibration_free(PSMoveCalibration *calibration)
 {
     psmove_return_if_fail(calibration != NULL);
 
-    free(calibration->filename);
-    free(calibration->system_filename);
+    psmove_free_mem(calibration->filename);
+    psmove_free_mem(calibration->system_filename);
     free(calibration);
 }
 

--- a/src/psmove_private.h
+++ b/src/psmove_private.h
@@ -149,7 +149,7 @@ ADDCALL _psmove_get_device_path(PSMove *move);
  *
  * The pointer *dest will be set to a newly-allocated byte array
  * of a certain size (which will be saved in *size) and the caller
- * has to free this field with free()
+ * has to free this field using \ref psmove_free_mem().
  **/
 ADDAPI int
 ADDCALL _psmove_get_zcm1_calibration_blob(PSMove *move, char **dest, size_t *size);
@@ -159,7 +159,7 @@ ADDCALL _psmove_get_zcm1_calibration_blob(PSMove *move, char **dest, size_t *siz
  *
  * The pointer *dest will be set to a newly-allocated byte array
  * of a certain size (which will be saved in *size) and the caller
- * has to free this field with free()
+ * has to free this field using \ref psmove_free_mem().
  **/
 ADDAPI int
 ADDCALL _psmove_get_zcm2_calibration_blob(PSMove *move, char **dest, size_t *size);
@@ -187,7 +187,8 @@ ADDCALL _psmove_btaddr_from_string(const char *string, PSMove_Data_BTAddr *dest)
 
 /**
  * Formats the contents of addr to a newly-allocated string and
- * returns it. The caller has to free() the return value.
+ * returns it. The caller has to free the return value using
+ * \ref psmove_free_mem().
  **/
 ADDAPI char *
 ADDCALL _psmove_btaddr_to_string(const PSMove_Data_BTAddr addr);
@@ -198,7 +199,8 @@ ADDCALL _psmove_btaddr_to_string(const PSMove_Data_BTAddr addr);
  * lowercase ... Make all characters lowercase if nonzero
  * separator ... The separator character (usually ':' or '-')
  *
- * The return value must be free()d by the caller.
+ * The return value must be freed by the caller using
+ * \ref psmove_free_mem().
  **/
 ADDAPI char *
 ADDCALL _psmove_normalize_btaddr(const char *addr, int lowercase, char separator);

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -162,7 +162,7 @@ PSMoveAPI::PSMoveAPI(EventReceiver *receiver, void *user_data)
         }
 
         std::string serial(tmp);
-        free(tmp);
+        psmove_free_mem(tmp);
 
         moves[serial].emplace_back(move);
     }
@@ -335,7 +335,7 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
                     self->controllers.emplace_back(c);
                 }
 
-                free(serial_number);
+                psmove_free_mem(serial_number);
             }
             break;
         case EVENT_DEVICE_REMOVED:

--- a/src/tracker/camera_control.cpp
+++ b/src/tracker/camera_control.cpp
@@ -97,7 +97,7 @@ camera_control_new_with_settings(int cameraID, int width, int height, int framer
     if (video) {
         psmove_DEBUG("Using '%s' as video input.\n", video);
         cc->capture = cvCaptureFromFile(video);
-        free(video);
+        psmove_free_mem(video);
     } else {
         cc->capture = cvCaptureFromCAM(cc->cameraID);
 

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -555,8 +555,8 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
 	char *intrinsics_xml = psmove_util_get_file_path(settings->intrinsics_xml);
 	char *distortion_xml = psmove_util_get_file_path(settings->distortion_xml);
 	camera_control_read_calibration(tracker->cc, intrinsics_xml, distortion_xml);
-	free(intrinsics_xml);
-	free(distortion_xml);
+	psmove_free_mem(intrinsics_xml);
+	psmove_free_mem(distortion_xml);
 
     tracker->cc_settings = camera_control_backup_system_settings(tracker->cc);
 
@@ -588,7 +588,7 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
 
         fclose(fp);
     }
-    free(filename);
+    psmove_free_mem(filename);
 #endif
 
     // Default to the distance parameters for the PS Eye camera
@@ -818,7 +818,7 @@ psmove_tracker_remember_color(PSMoveTracker *tracker, struct PSMove_RGBValue rgb
 
         fclose(fp);
     }
-    free(filename);
+    psmove_free_mem(filename);
 }
 
 enum PSMoveTracker_Status
@@ -843,12 +843,12 @@ psmove_tracker_blinking_calibration(PSMoveTracker *tracker, PSMove *move,
             printf("r: %d, g: %d, b: %d\n", r, g, b);
             *color = cvScalar(r, g, b, 0);
             *hsv_color = th_brg2hsv(*color);
-            free(color_str);
+            psmove_free_mem(color_str);
             return PSMove_True;
         } else {
             psmove_WARNING("Cannot parse color: '%s'\n", color_str);
         }
-        free(color_str);
+        psmove_free_mem(color_str);
     }
 
     psmove_tracker_update_image(tracker);

--- a/src/utils/magnetometer_calibration.c
+++ b/src/utils/magnetometer_calibration.c
@@ -239,7 +239,7 @@ main(int arg, char** args)
 			if (serial != NULL)
 			{
 				printf("Please delete %s.calibration and re-run \"psmove pair\" with the controller plugged into usb.", serial);
-				free(serial);
+				psmove_free_mem(serial);
 			}
 			else
 			{

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -71,7 +71,7 @@ int pair(const char *custom_addr)
                 printf("Pairing of #%d succeeded!\n", i+1);
                 char *serial = psmove_get_serial(move);
                 printf("Controller address: %s\n", serial);
-                free(serial);
+                psmove_free_mem(serial);
             } else {
                 printf("Pairing of #%d failed.\n", i+1);
             }

--- a/src/utils/psmoveremotepair.cpp
+++ b/src/utils/psmoveremotepair.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 
                 printf("Server has accepted pairing.\n");
 
-                free(serial);
+                psmove_free_mem(serial);
             } else {
                 printf("Failed to write new host address via USB.\n");
             }
@@ -107,7 +107,7 @@ int main(int argc, char* argv[])
         psmove_disconnect(move);
     }
 
-    free(new_host);
+    psmove_free_mem(new_host);
 
     moved_client_destroy(client);
 


### PR DESCRIPTION
In order to avoid possible problems with different runtimes, memory allocated by the library and passed to the caller should also be freed by the library, not by the caller. This is currently used mostly for strings such as the controller's BDADDR.

Alternatively, we could require library users to supply (custom) malloc/free for the library to use internally.