### PR TITLE
macOS: Add tracker libraries to package (Fixes #422)

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -95,12 +95,12 @@ case "$BUILD_TYPE" in
         BUILDDIR=build
         PLATFORM_BIN="
         build/psmove
+        build/test_tracker
         "
-        #build/test_tracker
         PLATFORM_LIB="
         build/libpsmoveapi.dylib
+        build/libpsmoveapi_tracker.dylib
         "
-        #build/libpsmoveapi_tracker.dylib
         pkg_tarball
 
         PYTHON_BINDINGS="build/psmove.py"


### PR DESCRIPTION
Let's add them again as suggested in #422. It has been disabled in c2382286f266ef43b650128dfa9eff2bf70dd298 for whatever reason.