### PR TITLE
Make magnetometer calibration independent of locale (Fixes #452)

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -46,6 +46,14 @@
 #include <math.h>
 #include <limits.h>
 
+#if defined(__linux) || defined(__APPLE__)
+#include <locale.h>
+#endif
+
+#if defined(__APPLE__)
+#include <xlocale.h>
+#endif
+
 #include "daemon/moved_client.h"
 #include "hidapi.h"
 
@@ -302,6 +310,38 @@ static int psmove_remote_disabled = 0;
 /* Number of valid, open PSMove* handles "in the wild" */
 static int psmove_num_open_handles = 0;
 
+
+static int
+psmove_fscanf_c(FILE *fp, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+#if !defined(_WIN32)
+    locale_t old = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0));
+#endif
+    int result = vfscanf(fp, fmt, args);
+#if !defined(_WIN32)
+    freelocale(uselocale(old));
+#endif
+    va_end(args);
+    return result;
+}
+
+static int
+psmove_fprintf_c(FILE *fp, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+#if !defined(_WIN32)
+    locale_t old = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0));
+#endif
+    int result = vfprintf(fp, fmt, args);
+#if !defined(_WIN32)
+    freelocale(uselocale(old));
+#endif
+    va_end(args);
+    return result;
+}
 
 
 /* Previously public functions, now private: */

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -47,9 +47,7 @@
 #include <limits.h>
 #include <stdarg.h>
 
-#if defined(__linux) || defined(__APPLE__)
 #include <locale.h>
-#endif
 
 #if defined(__APPLE__)
 #include <xlocale.h>
@@ -317,11 +315,13 @@ psmove_fscanf_c(FILE *fp, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-#if !defined(_WIN32)
+#if defined(_WIN32)
+    _locale_t loc = _create_locale(LC_NUMERIC, "C");
+    int result = _vfscanf_l(fp, fmt, loc, args);
+    _free_locale(loc);
+#else
     locale_t old = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0));
-#endif
     int result = vfscanf(fp, fmt, args);
-#if !defined(_WIN32)
     freelocale(uselocale(old));
 #endif
     va_end(args);
@@ -333,13 +333,17 @@ psmove_fprintf_c(FILE *fp, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-#if !defined(_WIN32)
+
+#if defined(_WIN32)
+    _locale_t loc = _create_locale(LC_NUMERIC, "C");
+    int result = _vfprintf_l(fp, fmt, loc, args);
+    _free_locale(loc);
+#else
     locale_t old = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0));
-#endif
     int result = vfprintf(fp, fmt, args);
-#if !defined(_WIN32)
     freelocale(uselocale(old));
 #endif
+
     va_end(args);
     return result;
 }

--- a/src/psmove_private.h
+++ b/src/psmove_private.h
@@ -88,8 +88,6 @@ extern "C" {
         {if(!(expr)){psmove_CRITICAL(#expr);return;}}
 #define psmove_return_val_if_fail(expr, val) \
         {if(!(expr)){psmove_CRITICAL(#expr);return(val);}}
-#define psmove_goto_if_fail(expr, label) \
-        {if(!(expr)){psmove_CRITICAL(#expr);goto label;}}
 
 /* Macro: Length of fixed-size array */
 #define ARRAY_LENGTH(x) (sizeof(x)/sizeof((x)[0]))


### PR DESCRIPTION
Force the `LC_NUMERIC` locale to be the `C` locale, so that `%f` writes/reads `.` always for floating point (and not `,`). As part of this change, also cleaned up the actual read/write code, as it was _much_ more complicated than necessary.

(Historical tidbit: The original code was written by me nearly 10 years ago, see bde8a6a20431261400a2f55f65243e444c17ca76 - quite silly in retrospect to do it like that when `printf()` and `scanf()` are perfectly capable of writing/reading verbatim characters...)

Not yet handled: Unsure how Win32 handles locales, it definitely doesn't seem to have `uselocale()` / `newlocale()` / `freelocale()` from a quick glance at mingw-w64 headers.