### PR TITLE
Implement psmove_tracker_count_connected() for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ starting after version 4.0.12, but historic entries might not.
 - Added `psmove_tracker_opencv.h` for OpenCV-specific functions
 - `psmove_fusion_glm.h`: Convenience wrapper functions returning `glm` types
 - `psmove_tracker_glm.h`: Convenience wrapper functions returning `glm` types
+- `psmove_tracker_count_connected()` now returns the number of connected V4L2 video devices on Linux
 
 ### Changed
 

--- a/src/tracker/camera_control.cpp
+++ b/src/tracker/camera_control.cpp
@@ -36,6 +36,10 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#if defined(__linux)
+#include <sys/stat.h>
+#endif
+
 #include "camera_control_private.h"
 
 void
@@ -125,11 +129,18 @@ int
 camera_control_count_connected()
 {
 #if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
-	ps3eye_init();
-	return ps3eye_count_connected();
+    ps3eye_init();
+    return ps3eye_count_connected();
+#elif defined(__linux)
+    int i = 0;
+    struct stat st;
+    while (::stat(("/dev/video" + std::to_string(i)).c_str(), &st) == 0 && S_ISCHR(st.st_mode)) {
+        ++i;
+    }
+    return i;
 #else
-	// Don't know how to get number of connected cameras through opencv...
-	return -1;
+    PSMOVE_WARNING("Getting number of connected cameras not implemented");
+    return -1;
 #endif
 }
 


### PR DESCRIPTION
Would be nice to implement this for macOS and Windows as well, but since we use `PS3EYEDriver` by default there, it's not as urgent.