### PR TITLE
Tracker: Cleanup RGB vs. BGR (vs. 'BRG') component ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ starting after version 4.0.12, but historic entries might not.
 - Removed support for the proprietary CL Eye Driver + Registry settings on Windows
 - Removed `psmove_tracker_get_frame()` (replaced with `psmove_tracker_opencv_get_frame()`)
 - Removed legacy OpenGL examples and glfw3 (only used for the OpenGL examples)
+- Removed support for the `PSMOVE_TRACKER_COLOR` environment variable
 
 
 ## [4.0.12] - 2020-12-19

--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -53,9 +53,6 @@ extern "C" {
 /* Name of the environment variable used to set the biggest ROI size */
 #define PSMOVE_TRACKER_ROI_SIZE_ENV "PSMOVE_TRACKER_ROI_SIZE"
 
-/* Name of the environment variable used to set a fixed tracker color */
-#define PSMOVE_TRACKER_COLOR_ENV "PSMOVE_TRACKER_COLOR"
-
 /* Name of the environment variables for the camera image size */
 #define PSMOVE_TRACKER_WIDTH_ENV "PSMOVE_TRACKER_WIDTH"
 #define PSMOVE_TRACKER_HEIGHT_ENV "PSMOVE_TRACKER_HEIGHT"

--- a/src/tracker/psmove_tracker.cpp
+++ b/src/tracker/psmove_tracker.cpp
@@ -834,21 +834,6 @@ static bool
 psmove_tracker_blinking_calibration(PSMoveTracker *tracker, PSMove *move,
         struct PSMove_RGBValue rgb, CvScalar *colorRGB, CvScalar *colorHSV)
 {
-    char *color_str = psmove_util_get_env_string(PSMOVE_TRACKER_COLOR_ENV);
-    if (color_str != NULL) {
-        int r, g, b;
-        if (sscanf(color_str, "%02x%02x%02x", &r, &g, &b) == 3) {
-            printf("r: %d, g: %d, b: %d\n", r, g, b);
-            *colorRGB = cvScalar(r, g, b, 0);
-            *colorHSV = th_rgb2hsv(*colorRGB);
-            psmove_free_mem(color_str);
-            return PSMove_True;
-        } else {
-            PSMOVE_WARNING("Cannot parse color: '%s'", color_str);
-        }
-        psmove_free_mem(color_str);
-    }
-
     psmove_tracker_update_image(tracker);
     IplImage* frame = tracker->frame;
     assert(frame != NULL);

--- a/src/tracker/tracker_helpers.cpp
+++ b/src/tracker/tracker_helpers.cpp
@@ -101,10 +101,10 @@ th_scalar_mul(CvScalar a, double b)
 }
 
 CvScalar
-th_brg2hsv(CvScalar bgr)
+th_rgb2hsv(CvScalar rgb)
 {
     static IplImage *img_hsv = NULL;
-    static IplImage *img_bgr = NULL;
+    static IplImage *img_rgb = NULL;
 
     /**
      * We use two dummy 1x1 images here, and set/get the color from from these
@@ -116,12 +116,12 @@ th_brg2hsv(CvScalar bgr)
         img_hsv = cvCreateImage(cvSize(1, 1), IPL_DEPTH_8U, 3);
     }
 
-    if (!img_bgr) {
-        img_bgr = cvCreateImage(cvSize(1, 1), IPL_DEPTH_8U, 3);
+    if (!img_rgb) {
+        img_rgb = cvCreateImage(cvSize(1, 1), IPL_DEPTH_8U, 3);
     }
 
-    cvSet(img_bgr, bgr, NULL);
-    cvCvtColor(img_bgr, img_hsv, CV_BGR2HSV);
+    cvSet(img_rgb, rgb, NULL);
+    cvCvtColor(img_rgb, img_hsv, CV_RGB2HSV);
 
     return cvAvg(img_hsv, NULL);
 }

--- a/src/tracker/tracker_helpers.h
+++ b/src/tracker/tracker_helpers.h
@@ -86,10 +86,10 @@ CvScalar
 th_scalar_mul(CvScalar a, double b);
 
 /**
- * Single-value colorspace conversion: BGR -> HSV
+ * Single-value colorspace conversion: RGB -> HSV
  **/
 CvScalar
-th_brg2hsv(CvScalar bgr);
+th_rgb2hsv(CvScalar rgb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Make it explicit which component ordering is used in the variable names. Work with RGB internally (which already was the case for some parts), convert to/from BGR when dealing with the CV image.