### PR TITLE
Append _ms suffix to time-related variables in tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ starting after version 4.0.12, but historic entries might not.
 - The MinGW builds now explicitly require Windows 7 as minimum version
 - Camera devices on Linux - when using OpenCV - are now properly detected and enumerated even if
   there are "holes" in the numbering (e.g. /dev/video1 exists, but /dev/video0 does not)
+- Renamed `calibration_blink_delay` in tracker settings to `calibration_blink_delay_ms`
 
 ### Fixed
 

--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -100,7 +100,7 @@ typedef struct {
 
     /* Settings for camera calibration process */
     enum PSMoveTracker_Exposure exposure_mode;  /* [Exposure_LOW] exposure mode for setting target luminance */
-    int calibration_blink_delay;                /* [200] number of milliseconds to wait between a blink  */
+    int calibration_blink_delay_ms;             /* [200] number of milliseconds to wait between a blink  */
     int calibration_diff_t;                     /* [20] during calibration, all grey values in the diff image below this value are set to black  */
     int calibration_min_size;                   /* [50] minimum size of the estimated glowing sphere during calibration process (in pixel)  */
     int calibration_max_distance;               /* [30] maximum displacement of the separate found blobs  */


### PR DESCRIPTION
Also fixed some misleading comments and clarified units (all in milliseconds).