### PR TITLE
Fix kernel center of erode/dilate filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ starting after version 4.0.12, but historic entries might not.
 - Fixed linking on macOS (`libSecurity`)
 - Fix macOS version detection for macOS 11 and newer (fixes #456)
 - `examples/labs/`: Fix building of Qt examples by migrating to Qt 5
+- Fixed the kernel center of CV-related image filters (was off-center before)
 
 ### Removed
 

--- a/src/tracker/psmove_tracker.cpp
+++ b/src/tracker/psmove_tracker.cpp
@@ -659,7 +659,7 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
 
 	// prepare structure used for erode and dilate in calibration process
 	int ks = 5; // Kernel Size
-	int kc = (ks + 1) / 2; // Kernel Center
+	int kc = 2; // Kernel Center
 	tracker->kCalib = cvCreateStructuringElementEx(ks, ks, kc, kc, CV_SHAPE_RECT, NULL);
 
 	return tracker;


### PR DESCRIPTION
A kernel with size 5 (0..4) has the center exactly at 2, not 3.