### PR TITLE
Cleaned up camera control settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ starting after version 4.0.12, but historic entries might not.
   there are "holes" in the numbering (e.g. /dev/video1 exists, but /dev/video0 does not)
 - Renamed `calibration_blink_delay` in tracker settings to `calibration_blink_delay_ms`
 - `psmove_tracker.h`: Default value for width/height/framerate is now -1 (to auto-pick a good value)
+- `psmove_tracker.h`: Camera exposure is now a float between 0.0 and 1.0, independent of camera API
 
 ### Fixed
 
@@ -70,6 +71,7 @@ starting after version 4.0.12, but historic entries might not.
 - Removed legacy OpenGL examples and glfw3 (only used for the OpenGL examples)
 - Removed support for the `PSMOVE_TRACKER_COLOR` environment variable
 - Removed default width/height/framerate from `psmove_tracker.h`
+- Removed unused camera settings from `PSMoveTrackerSettings`: auto gain, gain, auto white balance, brightness
 
 
 ## [4.0.12] - 2020-12-19

--- a/docs/camera.rst
+++ b/docs/camera.rst
@@ -66,8 +66,8 @@ kernel driver in OpenCV/V4L2.
 
 Supported resolutions:
 
-- 1280x800 @ 60 Hz
-- **640x400 @ 120 Hz** (default)
+- **1280x800 @ 60 Hz** (default)
+- 640x400 @ 120 Hz
 - 320x192 @ 240 Hz
 
 
@@ -89,8 +89,8 @@ kernel driver in OpenCV/V4L2.
 Supported resolutions:
 
 - 1920x1080 @ 30 Hz
-- 1280x800 @ 60 Hz
+- **1280x800 @ 60 Hz** (default)
 - 960x520 @ 60 Hz
-- **640x376 @ 120 Hz** (default)
+- 640x376 @ 120 Hz
 - 448x256 @ 120 Hz
 - 320x184 @ 240 Hz

--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -86,11 +86,7 @@ typedef struct {
     int camera_frame_width;                     /* [-1=auto] */
     int camera_frame_height;                    /* [-1=auto] */
     int camera_frame_rate;                      /* [-1=auto] */
-    enum PSMove_Bool camera_auto_gain;          /* [PSMove_False] */
-    int camera_gain;                            /* [0] [0,0xFFFF] */
-    enum PSMove_Bool camera_auto_white_balance; /* [PSMove_False] */
-    int camera_exposure;                        /* [(255 * 15) / 0xFFFF] [0,0xFFFF] */
-    int camera_brightness;                      /* [0] [0,0xFFFF] */
+    float camera_exposure;                      /* [0.3] [0.0,1.0] */
     enum PSMove_Bool camera_mirror;             /* [PSMove_True] mirror camera image horizontally */
 
     /* Settings for camera calibration process */

--- a/src/tracker/camera_control.cpp
+++ b/src/tracker/camera_control.cpp
@@ -324,3 +324,14 @@ camera_control_delete(CameraControl* cc)
     free(cc);
 }
 
+void
+camera_control_ps3eyedriver_set_parameters(CameraControl* cc, float exposure, bool mirror)
+{
+#if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN, 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE, 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE, int(0x1FF * std::min(1.f, std::max(0.f, exposure))));
+    ps3eye_set_parameter(cc->eye, PS3EYE_GAIN, 0);
+    ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, mirror);
+#endif
+}

--- a/src/tracker/camera_control.h
+++ b/src/tracker/camera_control.h
@@ -77,23 +77,11 @@ camera_control_delete(CameraControl* cc);
  * Set the camera parameters used during capturing
  *
  * cc         - the camera control to modify
- * autoE      - value range [0-0xFFFF]
- * autoG      - value range [0-0xFFFF]
- * autoWB     - value range [0-0xFFFF]
- * exposure   - value range [0-0xFFFF]
- * gain       - value range [0-0xFFFF]
- * wbRed      - value range [0-0xFFFF]
- * wbGreen    - value range [0-0xFFFF]
- * wbBlue     - value range [0-0xFFFF]
- * contrast   - value range [0-0xFFFF]
- * brightness - value range [0-0xFFFF]
+ * exposure   - exposure (0.0 .. 1.0)
+ * mirror     - whether to mirror the image horizontally
  **/
 void
-camera_control_set_parameters(CameraControl* cc,
-        int autoE, int autoG, int autoWB,
-        int exposure, int gain,
-        int wbRed, int wbGreen, int wbBlue,
-		int contrast, int brightness, enum PSMove_Bool h_flip);
+camera_control_set_parameters(CameraControl* cc, float exposure, bool mirror);
 
 struct CameraControlFrameLayout {
     int capture_width; /**< raw capture device width */

--- a/src/tracker/camera_control_private.h
+++ b/src/tracker/camera_control_private.h
@@ -66,3 +66,6 @@ struct _CameraControl {
 
 bool
 camera_control_fallback_frame_layout(CameraControl *cc, int width, int height, struct CameraControlFrameLayout *layout);
+
+void
+camera_control_ps3eyedriver_set_parameters(CameraControl* cc, float exposure, bool mirror);

--- a/src/tracker/platform/camera_control_macosx.cpp
+++ b/src/tracker/platform/camera_control_macosx.cpp
@@ -30,31 +30,9 @@
 #include "../camera_control_private.h"
 
 void
-camera_control_set_parameters(CameraControl* cc,
-        int autoE, int autoG, int autoWB,
-        int exposure, int gain,
-        int wbRed, int wbGreen, int wbBlue,
-        int contrast, int brightness, enum PSMove_Bool h_flip)
+camera_control_set_parameters(CameraControl *cc, float exposure, bool mirror)
 {
-#if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
-    //autoE... setAutoExposure not defined in ps3eye.h
-    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN, autoG > 0);
-    ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE, autoWB > 0);
-    ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE, (int)((511 * exposure) / 0xFFFF));
-    ps3eye_set_parameter(cc->eye, PS3EYE_GAIN, (int)((79 * gain) / 0xFFFF));
-    //ps3eye_set_parameter(cc->eye, PS3EYE_REDBALANCE, (int)((255 * wbRed) / 0xFFFF));
-    //wbGreen... setGreenBalance not defined in ps3eye.h
-    //ps3eye_set_parameter(cc->eye, PS3EYE_BLUEBALANCE, (int)((255 * wbBlue) / 0xFFFF));
-    //ps3eye_set_parameter(cc->eye, PS3EYE_CONTRAST, contrast);  // Transform unknown.
-    //ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS, brightness);  // Transform unknown.
-
-    /** The following parameters could be set but are not passed into this function:
-     * ps3eye_set_parameter(cc->eye, PS3EYE_SHARPNESS, ??);
-     * ps3eye_set_parameter(cc->eye, PS3EYE_HUE, ??);
-     * ps3eye_set_parameter(cc->eye, PS3EYE_VFLIP, ??);
-     **/
-    ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, h_flip);
-#endif
+    camera_control_ps3eyedriver_set_parameters(cc, exposure, mirror);
 }
 
 struct CameraControlSystemSettings *

--- a/src/tracker/platform/camera_control_win32.cpp
+++ b/src/tracker/platform/camera_control_win32.cpp
@@ -35,17 +35,6 @@
 #include "../camera_control.h"
 #include "../camera_control_private.h"
 
-struct CameraControlSystemSettings {
-    DWORD AutoAEC;
-    DWORD AutoAGC;
-    DWORD AutoAWB;
-    DWORD Exposure;
-    DWORD Gain;
-    DWORD wbB;
-    DWORD wbG;
-    DWORD wbR;
-};
-
 struct CameraControlSystemSettings *
 camera_control_backup_system_settings(CameraControl *cc)
 {
@@ -58,30 +47,10 @@ camera_control_restore_system_settings(CameraControl *cc,
 {
 }
 
-void camera_control_set_parameters(CameraControl* cc, int autoE, int autoG, int autoWB, int exposure, int gain, int wbRed, int wbGreen, int wbBlue, int contrast, int brightness, enum PSMove_Bool h_flip)
+void
+camera_control_set_parameters(CameraControl *cc, float exposure, bool mirror)
 {
-#if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
-	//autoE... setAutoExposure not defined in ps3eye.h
-	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_GAIN,				autoG > 0);
-	ps3eye_set_parameter(cc->eye, PS3EYE_AUTO_WHITEBALANCE,		autoWB > 0);
-	ps3eye_set_parameter(cc->eye, PS3EYE_EXPOSURE,				(int)((511 * exposure) / 0xFFFF));
-	ps3eye_set_parameter(cc->eye, PS3EYE_GAIN,					(int)((79 * gain) / 0xFFFF));
-	ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS,			(int)((255 * brightness) / 0xFFFF));
-	ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, 				h_flip);
-
-	//ps3eye_set_parameter(cc->eye, PS3EYE_REDBALANCE, (int)((255 * wbRed) / 0xFFFF));
-	//wbGreen... setGreenBalance not defined in ps3eye.h
-	//ps3eye_set_parameter(cc->eye, PS3EYE_BLUEBALANCE, (int)((255 * wbBlue) / 0xFFFF));
-	//ps3eye_set_parameter(cc->eye, PS3EYE_CONTRAST, contrast);  // Transform unknown.
-	//ps3eye_set_parameter(cc->eye, PS3EYE_BRIGHTNESS, brightness);  // Transform unknown.
-
-	/** The following parameters could be set but are not passed into this function:
-	* ps3eye_set_parameter(cc->eye, PS3EYE_SHARPNESS, ??);
-	* ps3eye_set_parameter(cc->eye, PS3EYE_HUE, ??);
-	* ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, ??);
-	* ps3eye_set_parameter(cc->eye, PS3EYE_VFLIP, ??);
-	**/
-#endif
+    camera_control_ps3eyedriver_set_parameters(cc, exposure, mirror);
 }
 
 bool


### PR DESCRIPTION
Tweaked exposure settings for PS4 and PS5 camera, fixed exposure locking for PS3 camera (on Linux). Change default resolution for PS4 and PS5 camera, as the capture resolution seems to affect the exposure behavior. Unify PS3EYEDriver camera setting.