### PR TITLE
Add psmove_tracker_get_camera_info()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ starting after version 4.0.12, but historic entries might not.
 - `psmove_tracker_count_connected()` now returns the number of connected V4L2 video devices on Linux
 - `psmove_tracker_get_next_unused_color()` for previewing the next tracked color
 - Added (Linux) support for PS4 Camera (tested with CUH-ZEY2) and PS5 Camera (tested with CFI-ZEY1)
+- `psmove_tracker_get_camera_info()` to get some metadata about the current camera
 
 ### Changed
 

--- a/include/psmove_tracker.h
+++ b/include/psmove_tracker.h
@@ -640,6 +640,18 @@ ADDAPI enum PSMove_Bool
 ADDCALL psmove_tracker_get_next_unused_color(PSMoveTracker *tracker,
         unsigned char *r, unsigned char *g, unsigned char *b);
 
+
+struct PSMoveCameraInfo {
+    const char *camera_name;
+    const char *camera_api;
+    int width;
+    int height;
+};
+
+ADDAPI const struct PSMoveCameraInfo *
+ADDCALL psmove_tracker_get_camera_info(PSMoveTracker *tracker);
+
+
 /**
  * \brief Destroy an existing tracker instance and free allocated resources
  *

--- a/src/tracker/camera_control.cpp
+++ b/src/tracker/camera_control.cpp
@@ -335,3 +335,23 @@ camera_control_ps3eyedriver_set_parameters(CameraControl* cc, float exposure, bo
     ps3eye_set_parameter(cc->eye, PS3EYE_HFLIP, mirror);
 #endif
 }
+
+struct PSMoveCameraInfo
+camera_control_fallback_get_camera_info(CameraControl *cc)
+{
+#if defined(CAMERA_CONTROL_USE_PS3EYE_DRIVER)
+    return PSMoveCameraInfo {
+        "PS3 Eye",
+        "PS3EYEDriver",
+        cc->layout.crop_width,
+        cc->layout.crop_height,
+    };
+#else
+    return PSMoveCameraInfo {
+        "Unknown camera",
+        "Unknown API",
+        cc->layout.crop_width,
+        cc->layout.crop_height,
+    };
+#endif
+}

--- a/src/tracker/camera_control.h
+++ b/src/tracker/camera_control.h
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include "psmove.h"
+#include "psmove_tracker.h"
 #include "../psmove_private.h"
 
 struct _CameraControl;
@@ -115,6 +116,9 @@ camera_control_backup_system_settings(CameraControl* cc);
 void
 camera_control_restore_system_settings(CameraControl* cc,
         struct CameraControlSystemSettings *settings);
+
+struct PSMoveCameraInfo
+camera_control_get_camera_info(CameraControl *cc);
 
 #ifdef __cplusplus
 }

--- a/src/tracker/camera_control_private.h
+++ b/src/tracker/camera_control_private.h
@@ -69,3 +69,6 @@ camera_control_fallback_frame_layout(CameraControl *cc, int width, int height, s
 
 void
 camera_control_ps3eyedriver_set_parameters(CameraControl* cc, float exposure, bool mirror);
+
+struct PSMoveCameraInfo
+camera_control_fallback_get_camera_info(CameraControl *cc);

--- a/src/tracker/platform/camera_control_linux.cpp
+++ b/src/tracker/platform/camera_control_linux.cpp
@@ -413,3 +413,35 @@ camera_control_get_frame_layout(CameraControl *cc, int width, int height, struct
 
     return camera_control_fallback_frame_layout(cc, width, height, layout);
 }
+
+struct PSMoveCameraInfo
+camera_control_get_camera_info(CameraControl *cc)
+{
+    const char *camera_name = "Unknown camera";
+
+    int fd = open_v4l2_device(cc->cameraID);
+    if (fd != -1) {
+        switch (identify_camera(fd)) {
+            case PS_CAMERA_PS3_EYE:
+                camera_name = "PS3 Eye";
+                break;
+            case PS_CAMERA_PS4_CAMERA:
+                camera_name = "PS4 Camera";
+                break;
+            case PS_CAMERA_PS5_CAMERA:
+                camera_name = "PS5 Camera";
+                break;
+            case PS_CAMERA_UNKNOWN:
+            default:
+                break;
+        }
+        v4l2_close(fd);
+    }
+
+    return PSMoveCameraInfo {
+        camera_name,
+        "V4L2",
+        cc->layout.crop_width,
+        cc->layout.crop_height,
+    };
+}

--- a/src/tracker/platform/camera_control_macosx.cpp
+++ b/src/tracker/platform/camera_control_macosx.cpp
@@ -59,3 +59,9 @@ camera_control_get_preferred_camera()
 {
     return -1;
 }
+
+struct PSMoveCameraInfo
+camera_control_get_camera_info(CameraControl *cc)
+{
+    return camera_control_fallback_get_camera_info(cc);
+}

--- a/src/tracker/platform/camera_control_win32.cpp
+++ b/src/tracker/platform/camera_control_win32.cpp
@@ -64,3 +64,9 @@ camera_control_get_preferred_camera()
 {
     return -1;
 }
+
+struct PSMoveCameraInfo
+camera_control_get_camera_info(CameraControl *cc)
+{
+    return camera_control_fallback_get_camera_info(cc);
+}

--- a/src/tracker/psmove_tracker.cpp
+++ b/src/tracker/psmove_tracker.cpp
@@ -168,6 +168,8 @@ struct _PSMoveTracker {
     float debug_fps; // the current FPS achieved by "psmove_tracker_update"
 
     bool fast_exposure; // whether to skip the dynamic exposure setting
+
+    PSMoveCameraInfo camera_info;
 };
 
 // -------- START: internal functions only
@@ -525,6 +527,8 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
         free(tracker);
         return NULL;
     }
+
+    tracker->camera_info = camera_control_get_camera_info(tracker->cc);
 
 	char *intrinsics_xml = psmove_util_get_file_path(settings->intrinsics_xml);
 	char *distortion_xml = psmove_util_get_file_path(settings->distortion_xml);
@@ -1842,4 +1846,10 @@ psmove_tracker_color_is_used(PSMoveTracker *tracker, struct PSMove_RGBValue colo
     }
 
     return 0;
+}
+
+const struct PSMoveCameraInfo *
+psmove_tracker_get_camera_info(PSMoveTracker *tracker)
+{
+    return &tracker->camera_info;
 }

--- a/src/utils/test_tracker.cpp
+++ b/src/utils/test_tracker.cpp
@@ -199,6 +199,12 @@ struct TrackerTestApp {
             tmp = format("Exposure: %s (press 'E' to cycle)", exposure_to_string(exposure));
             cvPutText(frame, tmp.c_str(), txt, &fontSmall, CvScalar{255.0, 255.0, 255.0, 255.0});
 
+            const auto camera_info = psmove_tracker_get_camera_info(tracker);
+
+            txt.y += 10;
+            tmp = format("%s %dx%d (%s)", camera_info->camera_name, camera_info->width, camera_info->height, camera_info->camera_api);
+            cvPutText(frame, tmp.c_str(), txt, &fontSmall, CvScalar{255.0, 255.0, 255.0, 255.0});
+
             cvShowImage(TEST_TRACKER_WINDOW_NAME, frame);
         }
     }


### PR DESCRIPTION
Return some metadata about the used camera during tracking, for overlaying on the test tracker app.