### PR TITLE
Implement PS4/PS5 camera capture support on macOS

### DIFF
--- a/docs/camera.rst
+++ b/docs/camera.rst
@@ -7,15 +7,13 @@ as it relates to tracking and the different variants for different OSes.
 PS3 Camera
 ----------
 
-This camera is supported on macOS, Linux and Windows. On macOS and Windows,
-PS3EYEDriver is used together with libusb. On Linux, the kernel includes
-built-in support for the camera using the ``ov534`` driver.
+This camera is always supported on Linux, and supported on macOS and Windows
+when using the PS3EYEDriver camera control driver.
+
+On Linux, the kernel includes built-in support for the camera using the
+``ov534`` driver, so the V4L2 camera control driver also support the PS3 Eye.
 
 The camera needs a USB 2.0 port.
-
-``PS3EYEDriver`` is the recommended and default way of interfacing with the
-camera on Windows and macOS. On Linux, the kernel has a built-in driver
-for the PS3 Eye camera, which is used via OpenCV/V4L2 by default.
 
 On Windows, you need to install `Zadig`_ (WinUSB driver) for the
 "USBCamera-B4.09.24.1" (or similar) device so that the PS3EYEDriver
@@ -36,8 +34,10 @@ Supported resolutions:
 PS4 Camera
 ----------
 
-This camera is currently supported on Linux only. You need to upload a
-firmware binary blob using the ``psmove camera-firmware`` command.
+This camera is currently supported on Linux when using the V4L2 camera control
+driver, and macOS when using the AVFoundation camera control driver.
+
+You need to upload a firmware binary blob using the ``psmove camera-firmware`` command.
 
 The camera needs a USB 3.0 port.
 
@@ -57,8 +57,9 @@ is no way yet to distinguish the PS4 and PS5 cameras from the USB
 descriptor in boot mode only, which is probably why the CFI-ZAA1 appears
 as USB parent device during enumeration).
 
-After the firmware upload the camera is supported using the ``uvcvideo``
-kernel driver in OpenCV/V4L2.
+After the firmware upload the camera is supported using
+the ``uvcvideo`` kernel driver in OpenCV/V4L2 (Linux)
+and ``UVCService`` on OpenCV/AVFoundation (macOS).
 
 - Tested models: CUH-ZEY2 ("round model v2")
 - Tested firmware SHA-1: ``fe86162309518a0ffe267075a2fcf728c5856b3e``
@@ -74,13 +75,16 @@ Supported resolutions:
 PS5 Camera
 ----------
 
-This camera is currently supported on Linux only. You need to upload a
-firmware binary blob using the ``psmove camera-firmware`` command.
+This camera is currently supported on Linux when using the V4L2 camera control
+driver, and macOS when using the AVFoundation camera control driver.
+
+You need to upload a firmware binary blob using the ``psmove camera-firmware`` command.
 
 The camera needs a USB 3.0 port.
 
-After the firmware upload the camera is supported using the ``uvcvideo``
-kernel driver in OpenCV/V4L2.
+After the firmware upload the camera is supported using
+the ``uvcvideo`` kernel driver in OpenCV/V4L2 (Linux)
+and ``UVCService`` on OpenCV/AVFoundation (macOS).
 
 - Tested models: CFI-ZEY1
 - Tested firmware SHA-1: ``0fa4da31a12b662a9a80abc8b84932770df8f7e1``

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -67,14 +67,12 @@ IF(PSMOVE_BUILD_TRACKER)
         IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             find_library(QUARTZCORE QuartzCore)
             find_library(APPKIT AppKit)
-            find_library(QTKIT QTKit)
             find_library(AVFOUNDATION AVFoundation)
             find_library(SECURITY Security)
             list(APPEND PSMOVEAPI_TRACKER_REQUIRED_LIBS
                 stdc++
                 ${QUARTZCORE}
                 ${APPKIT}
-                ${QTKIT}
                 ${AVFOUNDATION}
                 ${SECURITY})
         ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -102,6 +100,10 @@ IF(PSMOVE_BUILD_TRACKER)
         set(INFO_CAMERA_CONTROL_DRIVER "PS3EYEDriver")
         list(APPEND PSMOVEAPI_TRACKER_PLATFORM_SRC
             ${CMAKE_CURRENT_LIST_DIR}/camera_control_driver_ps3eyedriver.cpp)
+    ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set(INFO_CAMERA_CONTROL_DRIVER "AVFoundation")
+        list(APPEND PSMOVEAPI_TRACKER_PLATFORM_SRC
+            ${CMAKE_CURRENT_LIST_DIR}/camera_control_driver_avfoundation.mm)
     ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         set(INFO_CAMERA_CONTROL_DRIVER "V4L2")
         list(APPEND PSMOVEAPI_TRACKER_PLATFORM_SRC
@@ -132,6 +134,9 @@ list(APPEND PSMOVEAPI_TRACKER_SRC
 
     "${CMAKE_CURRENT_LIST_DIR}/camera_control_driver.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/camera_control_driver.h"
+
+    "${CMAKE_CURRENT_LIST_DIR}/camera_control_layouts.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/camera_control_layouts.h"
 
     "${ROOT_DIR}/include/psmove_fusion.h"
     "${ROOT_DIR}/include/psmove_tracker.h"

--- a/src/tracker/camera_control_driver_avfoundation.mm
+++ b/src/tracker/camera_control_driver_avfoundation.mm
@@ -1,0 +1,312 @@
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2023 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#include "camera_control.h"
+#include "camera_control_driver.h"
+#include "camera_control_layouts.h"
+
+#include "../psmove_private.h"
+
+#import "AVFoundation/AVFoundation.h"
+
+#include <map>
+#include <algorithm>
+#include <string>
+
+
+struct CameraControlAVFoundation : public CameraControlOpenCV {
+    CameraControlAVFoundation(int camera_id, int width, int height, int framerate);
+    virtual ~CameraControlAVFoundation();
+
+    virtual CameraControlFrameLayout get_frame_layout(int width, int height) override;
+    virtual void set_parameters(float exposure, bool mirror) override;
+    virtual PSMoveCameraInfo get_camera_info() override;
+
+    virtual CameraControlSystemSettings *backup_system_settings() override;
+    virtual void restore_system_settings(CameraControlSystemSettings *settings) override;
+};
+
+CameraControlAVFoundation::CameraControlAVFoundation(int camera_id, int width, int height, int framerate)
+    : CameraControlOpenCV(camera_id, width, height, framerate)
+{
+    capture = new cv::VideoCapture(cameraID);
+
+    layout = get_frame_layout(width, height);
+
+    capture->set(cv::CAP_PROP_FRAME_WIDTH, layout.capture_width);
+    capture->set(cv::CAP_PROP_FRAME_HEIGHT, layout.capture_height);
+    capture->set(cv::CAP_PROP_FPS, framerate);
+}
+
+CameraControlAVFoundation::~CameraControlAVFoundation()
+{
+}
+
+struct DetectedCamera {
+    DetectedCamera(const std::string &unique_id, const std::string &model_id, const std::string &localized_name)
+        : unique_id(unique_id)
+        , model_id(model_id)
+        , localized_name(localized_name)
+    {
+    }
+
+    enum PSCameraDevice device_type() const
+    {
+        if (model_id == "UVC Camera VendorID_1449 ProductID_1420") {
+            return PS_CAMERA_PS5_CAMERA;
+        } else if (model_id == "UVC Camera VendorID_1449 ProductID_1418") {
+            return PS_CAMERA_PS4_CAMERA;
+        }
+
+        return PS_CAMERA_UNKNOWN;
+    }
+
+    std::string unique_id;
+    std::string model_id;
+    std::string localized_name;
+};
+
+struct DetectedCameras {
+    DetectedCameras() = default;
+    ~DetectedCameras() = default;
+
+    void init()
+    {
+        if (inited) {
+            return;
+        }
+
+        AVCaptureDeviceDiscoverySession *discovery_session = [AVCaptureDeviceDiscoverySession
+            discoverySessionWithDeviceTypes: @[AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera]
+            mediaType: AVMediaTypeVideo
+            position: AVCaptureDevicePositionUnspecified];
+
+        static std::map<AVCaptureExposureMode, std::string> MODE_TO_STRING = {
+            { AVCaptureExposureModeLocked,                 "Locked" },
+            { AVCaptureExposureModeAutoExpose,             "AutoExpose" },
+            { AVCaptureExposureModeContinuousAutoExposure, "ContinuousAutoExposure" },
+            { AVCaptureExposureModeCustom,                 "Custom" },
+        };
+
+        auto exposureModeToString = [] (AVCaptureExposureMode mode) -> std::string {
+            auto it = MODE_TO_STRING.find(mode);
+            if (it == MODE_TO_STRING.end()) {
+                return std::to_string(mode);
+            }
+
+            return it->second;
+        };
+
+        for (AVCaptureDevice *capture_device in discovery_session.devices) {
+            BOOL locked = [capture_device lockForConfiguration: nullptr];
+            if (locked) {
+                PSMOVE_INFO("Camera Device: %s", [capture_device.modelID UTF8String]);
+
+                PSMOVE_INFO(" - Exposure mode: %s", exposureModeToString(capture_device.exposureMode).c_str());
+
+                PSMOVE_INFO(" - Supported modes:");
+                bool found = false;
+                for (const auto &mode_string: MODE_TO_STRING) {
+                    if ([capture_device isExposureModeSupported: mode_string.first]) {
+                        PSMOVE_INFO("   - %s", mode_string.second.c_str());
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    PSMOVE_INFO("   (none)");
+                }
+
+                [capture_device unlockForConfiguration];
+            }
+
+            cameras.emplace_back([capture_device.uniqueID UTF8String],
+                                 [capture_device.modelID UTF8String],
+                                 [capture_device.localizedName UTF8String]);
+        }
+
+        // Sort cameras in the same way as OpenCV sorts it, so the indices match (see cap_avfoundation_mac.mm)
+        std::sort(cameras.begin(), cameras.end(), [] (const DetectedCamera &a, const DetectedCamera &b) {
+            return a.unique_id <= b.unique_id;
+        });
+
+        [discovery_session release];
+
+        inited = true;
+    }
+
+    const DetectedCamera &get(int index)
+    {
+        init();
+
+        PSMOVE_VERIFY(index < cameras.size(), "index=%d, cameras.size()=%d", index, int(cameras.size()));
+
+        return cameras[index];
+    }
+
+    void each(std::function<void(int index, const DetectedCamera &camera)> callback)
+    {
+        init();
+
+        for (size_t i=0; i<cameras.size(); ++i) {
+            callback(i, cameras[i]);
+        }
+    }
+
+    size_t count()
+    {
+        init();
+
+        return cameras.size();
+    }
+
+private:
+    bool inited { false };
+    std::vector<DetectedCamera> cameras;
+};
+
+static DetectedCameras
+detected_cameras;
+
+struct CameraControlSystemSettings {
+    // TODO
+};
+
+CameraControlSystemSettings *
+CameraControlAVFoundation::backup_system_settings()
+{
+    // TODO
+
+    return new CameraControlSystemSettings();
+}
+
+void
+CameraControlAVFoundation::restore_system_settings(struct CameraControlSystemSettings *settings)
+{
+    if (!settings) {
+        return;
+    }
+
+    // TODO
+
+    delete settings;
+}
+
+void
+CameraControlAVFoundation::set_parameters(float exposure, bool mirror)
+{
+    // TODO
+}
+
+
+CameraControlFrameLayout
+CameraControlAVFoundation::get_frame_layout(int width, int height)
+{
+    const auto &camera = detected_cameras.get(cameraID);
+
+    auto camera_type = camera.device_type();
+
+    switch (camera_type) {
+        case PS_CAMERA_PS3_EYE:
+        case PS_CAMERA_PS4_CAMERA:
+        case PS_CAMERA_PS5_CAMERA:
+            return choose_camera_layout(camera_type, width, height);
+        case PS_CAMERA_UNKNOWN:
+            // TODO: Maybe query resolution from AVFoundation (see above)
+            break;
+    }
+
+    return CameraControlOpenCV::get_frame_layout(width, height);
+}
+
+PSMoveCameraInfo
+CameraControlAVFoundation::get_camera_info()
+{
+    const char *camera_name = "Unknown camera";
+
+    const auto &camera = detected_cameras.get(cameraID);
+
+    switch (camera.device_type()) {
+        case PS_CAMERA_PS3_EYE:
+            camera_name = "PS3 Eye";
+            break;
+        case PS_CAMERA_PS4_CAMERA:
+            camera_name = "PS4 Camera";
+            break;
+        case PS_CAMERA_PS5_CAMERA:
+            camera_name = "PS5 Camera";
+            break;
+        case PS_CAMERA_UNKNOWN:
+            camera_name = camera.localized_name.c_str();
+            break;
+        default:
+            break;
+    }
+
+    return PSMoveCameraInfo {
+        camera_name,
+        "AVFoundation",
+        layout.crop_width,
+        layout.crop_height,
+    };
+}
+
+CameraControl *
+camera_control_driver_new(int camera_id, int width, int height, int framerate)
+{
+    detected_cameras.init();
+
+    return new CameraControlAVFoundation(camera_id, width, height, framerate);
+}
+
+int
+camera_control_driver_get_preferred_camera()
+{
+    int result = -1;
+
+    detected_cameras.each([&] (int index, const DetectedCamera &camera) {
+        switch (camera.device_type()) {
+            case PS_CAMERA_PS3_EYE:
+            case PS_CAMERA_PS4_CAMERA:
+            case PS_CAMERA_PS5_CAMERA:
+                result = index;
+                break;
+            case PS_CAMERA_UNKNOWN:
+            default:
+                break;
+        }
+    });
+
+    return result;
+}
+
+int
+camera_control_driver_count_connected()
+{
+    return detected_cameras.count();
+}

--- a/src/tracker/camera_control_layouts.cpp
+++ b/src/tracker/camera_control_layouts.cpp
@@ -1,0 +1,92 @@
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2023 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+
+#include "camera_control_layouts.h"
+
+#include <unordered_map>
+
+namespace {
+
+static const std::unordered_map<PSCameraDevice, std::vector<CameraControlFrameLayout>>
+LAYOUTS = {
+    {
+        PS_CAMERA_PS3_EYE,
+        {
+            /* capture_width, capture_height, crop_x, crop_y, crop_width, crop_height */
+            {  640,  480,    0,    0,  640,  480 },
+            {  320,  240,    0,    0,  320,  240 },
+        },
+    },
+    {
+        PS_CAMERA_PS4_CAMERA,
+        {
+            /* capture_width, capture_height, crop_x, crop_y, crop_width, crop_height */
+            { 3448,  808,   48,    0, 1280,  800 },
+            { 1748,  408,   48,    0,  640,  400 },
+            {  898,  200,   48,    0,  320,  192 },
+        },
+    },
+    {
+        PS_CAMERA_PS5_CAMERA,
+        {
+            /* capture_width, capture_height, crop_x, crop_y, crop_width, crop_height */
+            { 2560,  800,    0,    0, 1280,  800 },
+            { 1920, 1080,    0,    0, 1920, 1080 },
+            {  960,  520,    0,    0,  960,  520 },
+            {  640,  376,    0,    0,  640,  376 },
+            {  640,  184,    0,    0,  320,  184 },
+        },
+    },
+};
+
+} // end anonymous namespace
+
+
+CameraControlFrameLayout
+choose_camera_layout(enum PSCameraDevice camera_type, int width, int height)
+{
+    auto it = LAYOUTS.find(camera_type);
+
+    PSMOVE_VERIFY(it != LAYOUTS.end(), "Could not find layouts for device type %d", int(camera_type));
+
+    auto &layouts = it->second;
+
+    if (width == -1 && height == -1) {
+        return layouts[0];
+    }
+
+    for (const auto &layout: layouts) {
+        if (layout.crop_width == width && layout.crop_height == height) {
+            return layout;
+        }
+    }
+
+    PSMOVE_FATAL("Unsupported resolution: %dx%d", width, height);
+    return layouts[0];
+}

--- a/src/tracker/camera_control_layouts.h
+++ b/src/tracker/camera_control_layouts.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2023 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+
+#include "camera_control_driver.h"
+
+enum PSCameraDevice {
+    PS_CAMERA_UNKNOWN = 0,
+    PS_CAMERA_PS3_EYE = 3,
+    PS_CAMERA_PS4_CAMERA = 4,
+    PS_CAMERA_PS5_CAMERA = 5,
+};
+
+CameraControlFrameLayout
+choose_camera_layout(enum PSCameraDevice camera_type, int width, int height);

--- a/src/tracker/psmove_tracker.cpp
+++ b/src/tracker/psmove_tracker.cpp
@@ -581,6 +581,7 @@ psmove_tracker_new_with_camera_and_settings(int camera, PSMoveTrackerSettings *s
 
     // We need to grab an image from the camera to determine the frame size
     psmove_tracker_update_image(tracker);
+    frame = tracker->frame;
 
     tracker->settings.search_tile_width = w;
     tracker->settings.search_tile_height = h;

--- a/src/utils/ps4_camera_firmware.cpp
+++ b/src/utils/ps4_camera_firmware.cpp
@@ -119,7 +119,12 @@ upload_firmware(libusb_context *context, libusb_device *dev, const std::vector<c
 
     std::vector<uint8_t> chunk = { 0x5b };
     res = libusb_control_transfer(handle, 0x40, 0x00, 0x2200, 0x8018, chunk.data(), chunk.size(), 1000);
+
+#if defined(__APPLE__)
+    PSMOVE_VERIFY(res == -1, "res = %d", res);
+#else
     PSMOVE_VERIFY(res == LIBUSB_ERROR_NO_DEVICE, "res = %d", res);
+#endif
 
     // As the device gets disconnected, we don't do libusb_close() here, and
     // instead rely on the process being closed and all resources freed. This

--- a/src/utils/test_camera.cpp
+++ b/src/utils/test_camera.cpp
@@ -98,6 +98,21 @@ main(int argc, char *argv[])
 
         IplImage *frame = psmove_tracker_opencv_get_frame(tracker);
         if (frame) {
+            for (int col=0; col<7; ++col) {
+                int x = col * (frame->width - 1) / 6;
+                cv::line(cv::cvarrToMat(frame), cv::Point(x, 0), cv::Point(x, frame->height - 1), cvScalar(255, (col==3)?255:0, 0, 0));
+
+                int y = col * (frame->height - 1) / 6;
+                cv::line(cv::cvarrToMat(frame), cv::Point(0, y), cv::Point(frame->width - 1, y), cvScalar(0, (col==3)?255:0, 255, 0));
+            }
+
+            const auto camera_info = psmove_tracker_get_camera_info(tracker);
+
+            CvFont fontSmall = cvFont(0.8, 1);
+            CvPoint txt = cvPoint(30, 30);
+            std::string tmp = format("%s %dx%d (%s)", camera_info->camera_name, camera_info->width, camera_info->height, camera_info->camera_api);
+            cvPutText(frame, tmp.c_str(), txt, &fontSmall, CvScalar{255.0, 255.0, 255.0, 255.0});
+
             cvShowImage("live camera feed", frame);
         }
     }


### PR DESCRIPTION
Exposure and mirror setting isn't supported, but camera detection using `AVFoundation` and resolution setting is.