### PR TITLE
Improved color calibration methods (blinking, hue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ starting after version 4.0.12, but historic entries might not.
 - Added (Linux) support for PS4 Camera (tested with CUH-ZEY2) and PS5 Camera (tested with CFI-ZEY1)
 - `psmove_tracker_get_camera_info()` to get some metadata about the current camera
 - new sub-command `test-undistortion` for `psmove` to test a calibration XML file
+- New hue-based fast color calibration: `psmove_tracker_hue_calibration()`
+- Runtime color calibration reset using `psmove_tracker_reset_color_calibration()`
 
 ### Changed
 
@@ -50,6 +52,8 @@ starting after version 4.0.12, but historic entries might not.
 - `psmove_tracker.h`: Default value for width/height/framerate is now -1 (to auto-pick a good value)
 - `psmove_tracker.h`: Camera exposure is now a float between 0.0 and 1.0, independent of camera API
 - Replaced `enum PSMove_Bool`, `PSMove_True` and `PSMove_False` with C99 (`stdbool.h`) / C++ `bool`, `true`, `false`
+- Increased maximum number of tracked controllers from 5 to 7
+- Blinking calibration now takes the new hue-based quality criteria into account, does per-controller dimming
 
 ### Fixed
 
@@ -74,7 +78,12 @@ starting after version 4.0.12, but historic entries might not.
 - Removed default width/height/framerate from `psmove_tracker.h`
 - Removed unused camera settings from `PSMoveTrackerSettings`: auto gain, gain, auto white balance, brightness
 - Removed support for cross-compiling for Windows using MinGW (use MSVC instead on Windows)
-
+- Removed `psmove_tracker_set_dimming()` and `psmove_tracker_get_dimming()`, removed global `dimming_factor` from tracker settings
+  (replaced with automatic per-controller dimming during color calibration)
+- Removed `psmove_tracker_set_camera_color()` without replacement
+- Removed `PSMOVE_TRACKER_ROI_SIZE` environment variable
+- Color mappings are not stored persistently anymore, but always re-calibrated at runtime
+- Removed `psmove_util_get_env_string()` from public API
 
 ## [4.0.12] - 2020-12-19
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -20,13 +20,6 @@ PSMOVE_TRACKER_FILENAME
 
          export PSMOVE_TRACKER_FILENAME=demo.avi # Will play demo.avi
 
-PSMOVE_TRACKER_ROI_SIZE
-    If set, this controls the size of the biggest (initial) ROI that will be used to track the controller. Bigger means slower in general, but recovery from tracking loss might be faster.
-
-    Example: ::
-
-        export PSMOVE_TRACKER_ROI_SIZE=200
-
 PSMOVE_TRACKER_WIDTH, PSMOVE_TRACKER_HEIGHT
     If set, these variables control the desired size of the camera picture.
 
@@ -36,3 +29,9 @@ PSMOVE_TRACKER_WIDTH, PSMOVE_TRACKER_HEIGHT
         export PSMOVE_TRACKER_HEIGHT=720
 
 
+PSMOVE_TRACKER_CAMERA_CALIBRATION
+    If set, this points to an XML file created by ``psmove calibrate-camera``.
+
+    Example: ::
+
+       export PSMOVE_TRACKER_CAMERA_CALIBRATION=pseye.xml

--- a/include/psmove.h
+++ b/include/psmove.h
@@ -1565,21 +1565,6 @@ ADDAPI int
 ADDCALL psmove_util_get_env_int(const char *name);
 
 /**
- * \brief Get a string from an environment variable
- *
- * Utility function used to get configuration from environment
- * variables.
- *
- * \param name The name of the environment variable
- *
- * \return The string value of the environment variable, or NULL if the
- *         variable is not set. The caller must free the result using
- *         \ref psmove_free_mem() when it is not needed anymore.
- **/
-ADDAPI char *
-ADDCALL psmove_util_get_env_string(const char *name);
-
-/**
  * \brief Sleep for a specific amount of milliseconds.
  *
  * \param ms The amount of milliseconds to sleep

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -2496,18 +2496,6 @@ psmove_util_get_env_int(const char *name)
 }
 
 char *
-psmove_util_get_env_string(const char *name)
-{
-    char *env = getenv(name);
-
-    if (env) {
-        return strdup(env);
-    }
-
-    return NULL;
-}
-
-char *
 _psmove_normalize_btaddr_inplace(char *addr, bool lowercase, char separator)
 {
     size_t count = strlen(addr);

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -123,6 +123,7 @@ ENDIF()
 
 set(PSMOVEAPI_TRACKER_SRC)
 list(APPEND PSMOVEAPI_TRACKER_SRC
+    "${CMAKE_CURRENT_LIST_DIR}/psmove_tracker_hue_calibration.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/psmove_tracker.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/psmove_fusion.cpp"
 

--- a/src/tracker/camera_control.cpp
+++ b/src/tracker/camera_control.cpp
@@ -76,10 +76,9 @@ camera_control_new_with_settings(int cameraID, int width, int height, int framer
 
     CameraControl *cc = nullptr;
 
-    char *video = psmove_util_get_env_string(PSMOVE_TRACKER_FILENAME_ENV);
+    const char *video = getenv(PSMOVE_TRACKER_FILENAME_ENV);
     if (video) {
         cc = new CameraControlVideoFile(video, width, height, framerate);
-        psmove_free_mem(video);
     } else {
         cc = camera_control_driver_new(cameraID, width, height, framerate);
     }
@@ -96,6 +95,10 @@ camera_control_set_deinterlace(CameraControl *cc, bool enabled)
 void
 camera_control_read_calibration(CameraControl* cc, const char *filename)
 {
+    if (filename == nullptr) {
+        filename = getenv(PSMOVE_TRACKER_CAMERA_CALIBRATION_ENV);
+    }
+
     if (filename == nullptr) {
         PSMOVE_INFO("No camera calibration");
         return;

--- a/src/tracker/psmove_tracker_hue_calibration.cpp
+++ b/src/tracker/psmove_tracker_hue_calibration.cpp
@@ -1,0 +1,346 @@
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2022, 2023 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#include <algorithm>
+
+#include "opencv2/core/core_c.h"
+#include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/highgui/highgui_c.h"
+
+#include "psmove_tracker.h"
+#include "psmove_tracker_opencv.h"
+
+#include "psmove_tracker_hue_calibration.h"
+
+#include "../psmove_private.h"
+#include "../psmove_port.h"
+#include "../psmove_format.h"
+
+#include "tracker_helpers.h"
+
+namespace {
+
+struct HueCalibrationImage {
+    HueCalibrationImage(CvScalar hsv)
+        : hsv(hsv)
+        , rgb(th_hsv2rgb(hsv))
+    {
+        PSMOVE_INFO("rgb @ hue=%f: %f %f %f", hsv.val[0], rgb.val[0], rgb.val[1], rgb.val[2]);
+    }
+
+    CvScalar hsv;
+    CvScalar rgb;
+
+    IplImage *on_image { nullptr };
+};
+
+} // end anonymous namespace
+
+
+namespace psmove {
+namespace tracker {
+
+HueCalibrationInfo::HueCalibrationInfo(float hue, float dimming, CvScalar cam_hsv, float background_match_fraction)
+    : hue(hue)
+    , dimming(dimming)
+    , cam_hsv{float(cam_hsv.val[0]), float(cam_hsv.val[1]), float(cam_hsv.val[2])}
+    , background_match_fraction(background_match_fraction)
+{
+}
+
+CvScalar
+HueCalibrationInfo::diff_hsv() const
+{
+    return cvScalar(
+        cam_hsv[0] - hue,
+        cam_hsv[1] - 255.f,
+        cam_hsv[2] - 255.f,
+        0.f
+    );
+}
+
+float
+HueCalibrationInfo::penalty_score() const
+{
+    auto diff = diff_hsv();
+
+    return -2.f * std::abs(diff.val[0]) + 0.1f * diff.val[1] + 0.1f * diff.val[2] - 5000.f * background_match_fraction;
+}
+
+CvScalar
+HueCalibrationInfo::rgb() const
+{
+    return th_hsv2rgb(cvScalar(hue, 255.f, 255.f, 255.f));
+}
+
+
+bool
+ColorCalibrationCollection::add(const HueCalibrationInfo &info, float max_hue_distance)
+{
+    float h = info.cam_hsv[0];
+    float s = info.cam_hsv[1];
+    float v = info.cam_hsv[2];
+
+    float hue_distance = std::abs(info.diff_hsv().val[0]);
+
+    if (h < 1.f && s < 1.f && v < 1.f) {
+        PSMOVE_WARNING("Ignoring - could not find/mask color");
+    } else if (max_hue_distance > 0.f && hue_distance > max_hue_distance) {
+        PSMOVE_WARNING("Ignoring - hue in camera too far apart");
+    } else if (v <= 90 && s <= 90) {
+        PSMOVE_WARNING("Ignoring - value AND saturation are too low");
+    } else if (v <= 120 || s <= 120) {
+        PSMOVE_WARNING("Ignoring - value OR saturation are too low");
+    } else {
+        auto it = map.find(info.hue);
+
+        // If we don't have one yet or we found a better one, save it
+        if (it == map.end() || (it->second.penalty_score() < info.penalty_score())) {
+            map[info.hue] = info;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+std::vector<HueCalibrationInfo>
+ColorCalibrationCollection::build() const
+{
+    std::vector<HueCalibrationInfo> result;
+
+    for (const auto it: map) {
+        const auto &info = it.second;
+
+        PSMOVE_INFO("hue: %f", info.hue);
+
+        auto rgb = info.rgb();
+
+        PSMOVE_INFO("dimming: %f", info.dimming);
+        PSMOVE_INFO("rgb = (%f, %f, %f)", rgb.val[0], rgb.val[1], rgb.val[2]);
+        PSMOVE_INFO("cam_hsv = (%f, %f, %f)", info.cam_hsv[0], info.cam_hsv[1], info.cam_hsv[2]);
+        PSMOVE_INFO("background_match_fraction = %d %%", int(100 * info.background_match_fraction));
+        PSMOVE_INFO("score = %.2f", info.penalty_score());
+        PSMOVE_INFO("-");
+
+        result.emplace_back(info);
+    }
+
+    std::sort(result.begin(), result.end(), sort_order);
+
+    return result;
+}
+
+bool
+ColorCalibrationCollection::sort_order(const HueCalibrationInfo &a, const HueCalibrationInfo &b)
+{
+    // Lower penalty equals higher rank
+    return a.penalty_score() >= b.penalty_score();
+}
+
+
+std::vector<HueCalibrationInfo>
+hue_calibration_internal(PSMoveTracker *tracker, PSMove *move, CvSize size,
+        std::function<IplImage *()> get_frame, CvScalar rHSV, IplConvKernel *kCalib)
+{
+    // This might need to be adjusted depending on background noise
+    int hue_diff_threshold = 40;
+
+    ColorCalibrationCollection color_calibration_collection;
+
+    int e = int(100 * psmove_tracker_get_exposure(tracker));
+
+    int dimming_steps = 3;
+    for (int d=0; d<dimming_steps; ++d) {
+        float dim = powf(0.3f, d);
+        PSMOVE_INFO("Dimming: %f (d=%d)", dim, d);
+
+        std::vector<HueCalibrationImage> hue_images;
+
+        auto hsv = cvScalar(0.0, 255.0, 255.0, 1.0);
+
+        int steps = std::max(5, psmove_count_connected() + 1);
+
+        double offset = 0.5;
+        double cycle = 180.0;
+
+        double hue_distance = cycle / steps;
+        PSMOVE_INFO("Hue distance: %.2f", hue_distance);
+
+        hsv.val[0] = offset * cycle / steps;
+        while (hsv.val[0] < cycle) {
+            hue_images.emplace_back(hsv);
+            hsv.val[0] += cycle / steps;
+        }
+
+        IplImage *off_image = cvCreateImage(size, 8, 3);
+        IplImage *hsv_off_image = cvCreateImage(size, 8, 3);
+        IplImage *gray_on_image = cvCreateImage(size, 8, 1);
+        IplImage *gray_off_image = cvCreateImage(size, 8, 1);
+        IplImage *diff_image = cvCreateImage(size, 8, 1);
+        IplImage *mask_image = nullptr;
+        IplImage *inv_mask_image = cvCreateImage(size, 8, 1);
+
+        {
+            // turn off the controller
+            psmove_set_leds(move, 0, 0, 0);
+            psmove_update_leds(move);
+
+            // capture the scene with the controller unlit
+            IplImage *off_out = get_frame();
+            cvCopy(off_out, off_image, NULL);
+            //th_dump_image(format("hue-off-dim%d-exp%d.png", d, e), off_image);
+
+            cvCvtColor(off_image, gray_off_image, CV_BGR2GRAY);
+            cvCvtColor(off_image, hsv_off_image, CV_BGR2HSV);
+        }
+
+        // go through all the hues and capture the images (+ build a mask)
+        for (auto &hue_image: hue_images) {
+            int hue = hue_image.hsv.val[0];
+
+            // turn on the controller
+            psmove_set_leds(move, hue_image.rgb.val[0] * dim, hue_image.rgb.val[1] * dim, hue_image.rgb.val[2] * dim);
+            psmove_update_leds(move);
+
+            IplImage *on_out = get_frame();
+            //th_dump_image(format("hue-on-h%d-dim%d-exp%d.png", hue, d, e), on_out);
+
+            hue_image.on_image = cvCloneImage(on_out);
+
+            cvCvtColor(on_out, gray_on_image, CV_RGB2GRAY);
+            cvAbsDiff(gray_on_image, gray_off_image, diff_image);
+            //th_dump_image(format("hue-diff-h%d-dim%d-exp%d.png", hue, d, e), diff_image);
+
+            cvThreshold(diff_image, diff_image, hue_diff_threshold, 0xFF /* white */, CV_THRESH_BINARY);
+            //th_dump_image(format("hue-diff-thr-h%d-dim%d-exp%d.png", hue, d, e), diff_image);
+
+            cvErode(diff_image, diff_image, kCalib, 1);
+            cvDilate(diff_image, diff_image, kCalib, 1);
+            //th_dump_image(format("hue-diff-denoise-h%d-dim%d-exp%d.png", hue, d, e), diff_image);
+
+            if (!mask_image) {
+                mask_image = cvCreateImage(size, 8, 1);
+                cvCopy(diff_image, mask_image, NULL);
+            } else {
+                cvAnd(diff_image, mask_image, mask_image, NULL);
+            }
+        }
+
+        //th_dump_image(format("hue-mask-dim%d-exp%d.png", d, e), mask_image);
+
+        // inverse mask for hue detection and environment hue detection
+        cvNot(mask_image, inv_mask_image);
+
+        // turn off the controller again
+        psmove_set_leds(move, 0, 0, 0);
+        psmove_update_leds(move);
+
+        for (auto &hue_image: hue_images) {
+            int hue = hue_image.hsv.val[0];
+
+            // zero out all pixels not in the mask
+            cvSet(hue_image.on_image, cvScalar(0.0, 0.0, 0.0, 0.0), inv_mask_image);
+            //th_dump_image(format("hue-color-masked-h%d-dim%d-exp%d.png", hue, d, e), hue_image.on_image);
+
+            IplImage *hsv_image = cvCloneImage(hue_image.on_image);
+            cvCvtColor(hue_image.on_image, hsv_image, CV_BGR2HSV);
+            auto average_hsv = cvAvg(hsv_image, mask_image);
+            cvReleaseImage(&hsv_image);
+
+            // calculate upper & lower bounds for the color filter
+            CvScalar min = th_scalar_sub(average_hsv, rHSV);
+            CvScalar max = th_scalar_add(average_hsv, rHSV);
+
+            IplImage *environment_hsv_image = cvCloneImage(hsv_off_image);
+            IplImage *environment_mask_image = cvCreateImage(size, 8, 1);
+            cvInRangeS(environment_hsv_image, min, max, environment_mask_image);
+            cvReleaseImage(&environment_hsv_image);
+
+            auto info = psmove::tracker::HueCalibrationInfo(hue_image.hsv.val[0], dim, average_hsv,
+                    float(cvCountNonZero(environment_mask_image)) / float(size.width * size.height));
+
+            auto diff_hsv = info.diff_hsv();
+
+            std::vector<std::string> info_text = {
+                format("Dimming stage:        dim=%.5f", dim),
+
+                format("Original RGB:         R=%3d, G=%3d, B=%3d", int(hue_image.rgb.val[0]), int(hue_image.rgb.val[1]), int(hue_image.rgb.val[2])),
+                format("Dimmed RGB:           R=%3d, G=%3d, B=%3d", int(hue_image.rgb.val[0]*dim), int(hue_image.rgb.val[1]*dim), int(hue_image.rgb.val[2]*dim)),
+
+                format("Original HSV:         H=%3d, S=%3d, V=%3d", int(hue_image.hsv.val[0]), int(hue_image.hsv.val[1]), int(hue_image.hsv.val[2])),
+                format("Average HSV (masked): H=%3d, S=%3d, V=%3d", int(average_hsv.val[0]), int(average_hsv.val[1]), int(average_hsv.val[2])),
+                format("Difference in HSV:    H=%3d, S=%3d, V=%3d", int(diff_hsv.val[0]), int(diff_hsv.val[1]), int(diff_hsv.val[2])),
+                format("Environment match:    %d %%", int(100 * info.background_match_fraction)),
+
+                format("Penalty score:        %.2f", info.penalty_score()),
+            };
+
+            CvFont fontSmall = cvFont(0.8, 1);
+            int x = 10;
+            int y = 300;
+
+            for (auto &line: info_text) {
+                cvPutText(hue_image.on_image, line.c_str(), cvPoint(x, y), &fontSmall, cvScalar(255, 255, 255, 255));
+                y += 10;
+
+                PSMOVE_INFO("%s", line.c_str());
+            }
+            PSMOVE_INFO("---");
+
+            // for debugging, show the original RGB value in the image
+            cvRectangle(hue_image.on_image, cvPoint(x, y), cvPoint(x+50, y+50), th_rgb2bgr(hue_image.rgb), CV_FILLED, 8, 0);
+            y += 50;
+
+            if (color_calibration_collection.add(info, hue_distance * 0.8f)) {
+                //th_dump_image(format("hue-color-masked-annotated-exp%d-h%03d-dim%d-envmask.png", e, hue, d), environment_mask_image);
+                //th_dump_image(format("hue-color-masked-annotated-exp%d-h%03d-dim%d.png", e, hue, d), hue_image.on_image);
+            } else {
+                //th_dump_image(format("excluded-hue-color-masked-annotated-exp%d-h%03d-dim%d-envmask.png", e, hue, d), environment_mask_image);
+                //th_dump_image(format("excluded-hue-color-masked-annotated-exp%d-h%03d-dim%d.png", e, hue, d), hue_image.on_image);
+            }
+
+            cvReleaseImage(&environment_mask_image);
+            cvReleaseImage(&hue_image.on_image);
+        }
+
+        cvReleaseImage(&off_image);
+        cvReleaseImage(&hsv_off_image);
+        cvReleaseImage(&gray_on_image);
+        cvReleaseImage(&gray_off_image);
+        cvReleaseImage(&diff_image);
+        cvReleaseImage(&mask_image);
+        cvReleaseImage(&inv_mask_image);
+    }
+
+    return color_calibration_collection.build();
+}
+
+} // end namespace tracker
+} // end namespace psmove

--- a/src/tracker/psmove_tracker_hue_calibration.h
+++ b/src/tracker/psmove_tracker_hue_calibration.h
@@ -1,0 +1,76 @@
+#pragma once
+
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2022, 2023 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#include "psmove.h"
+
+#include "opencv2/core/core_c.h"
+
+#include "tracker_helpers.h"
+
+#include <vector>
+#include <unordered_map>
+
+
+namespace psmove {
+namespace tracker {
+
+struct HueCalibrationInfo {
+    HueCalibrationInfo() = default;
+
+    HueCalibrationInfo(float hue, float dimming, CvScalar cam_hsv, float background_match_fraction=0.f);
+    CvScalar diff_hsv() const;
+    float penalty_score() const;
+    CvScalar rgb() const;
+
+    float hue { 0.f }; // target hue value (S = 255, V = 255)
+    float dimming { 1.f }; // dimming value (0.01 dark -> 1.0 bright)
+    float cam_hsv[3] { 0.f, 0.f, 0.f }; // HSV value seen by camera
+    float background_match_fraction { 0.f }; // fraction of pixels matching HSV range in background
+};
+
+struct ColorCalibrationCollection {
+    ColorCalibrationCollection() = default;
+
+    bool add(const HueCalibrationInfo &info, float max_hue_distance=0.f);
+    std::vector<HueCalibrationInfo> build() const;
+
+private:
+    static bool sort_order(const HueCalibrationInfo &a, const HueCalibrationInfo &b);
+
+    std::unordered_map<float, HueCalibrationInfo> map;
+};
+
+std::vector<HueCalibrationInfo>
+hue_calibration_internal(PSMoveTracker *tracker, PSMove *move,
+        CvSize size, std::function<IplImage *()> get_frame,
+        CvScalar rHSV, IplConvKernel *kCalib);
+
+} // namespace tracker
+} // namespace psmove

--- a/src/tracker/tracker_helpers.cpp
+++ b/src/tracker/tracker_helpers.cpp
@@ -32,6 +32,7 @@
 #include "tracker_helpers.h"
 
 #include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/imgcodecs.hpp"
 
 void
 th_stats(double *a, int n, double *variance, double *avg)
@@ -126,3 +127,35 @@ th_rgb2hsv(CvScalar rgb)
     return cvAvg(img_hsv, NULL);
 }
 
+
+CvScalar
+th_hsv2rgb(CvScalar hsv)
+{
+    static IplImage *img_hsv = NULL;
+    static IplImage *img_rgb = NULL;
+
+    /**
+     * We use two dummy 1x1 images here, and set/get the color from from these
+     * images (using cvSet/cvAvg) in order to be able to use cvCvtColor() and
+     * the same algorithm used when using cvCvtColor() on the camera image.
+     **/
+
+    if (!img_hsv) {
+        img_hsv = cvCreateImage(cvSize(1, 1), IPL_DEPTH_8U, 3);
+    }
+
+    if (!img_rgb) {
+        img_rgb = cvCreateImage(cvSize(1, 1), IPL_DEPTH_8U, 3);
+    }
+
+    cvSet(img_hsv, hsv, NULL);
+    cvCvtColor(img_hsv, img_rgb, CV_HSV2RGB);
+
+    return cvAvg(img_rgb, NULL);
+}
+
+void
+th_dump_image(const std::string &filename, IplImage *image)
+{
+    cv::imwrite(filename, cv::cvarrToMat(image));
+}

--- a/src/tracker/tracker_helpers.h
+++ b/src/tracker/tracker_helpers.h
@@ -91,6 +91,22 @@ th_scalar_mul(CvScalar a, double b);
 CvScalar
 th_rgb2hsv(CvScalar rgb);
 
+/**
+ * Single-value colorspace conversion: HSV -> RGB
+ **/
+CvScalar
+th_hsv2rgb(CvScalar hsv);
+
+/* Yes, those two functions do the same thing, but we want to have both names for semantics */
+static inline CvScalar th_bgr2rgb(CvScalar bgr) { return cvScalar(bgr.val[2], bgr.val[1], bgr.val[0], bgr.val[2]); }
+static inline CvScalar th_rgb2bgr(CvScalar rgb) { return cvScalar(rgb.val[2], rgb.val[1], rgb.val[0], rgb.val[2]); }
+
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * Write to an image file
+ **/
+void
+th_dump_image(const std::string &filename, IplImage *image);

--- a/src/utils/test_camera.cpp
+++ b/src/utils/test_camera.cpp
@@ -50,7 +50,6 @@ main(int argc, char *argv[])
 {
     PSMoveTrackerSettings settings;
     psmove_tracker_settings_set_default(&settings);
-    settings.color_mapping_max_age = 0;
     settings.camera_mirror = true;
 
     char *progname = argv[0];
@@ -63,11 +62,11 @@ main(int argc, char *argv[])
             --argc;
 
             if (strcmp(argv[0], "low") == 0) {
-                settings.exposure_mode = Exposure_LOW;
+                settings.camera_exposure = 0.1f;
             } else if (strcmp(argv[0], "medium") == 0) {
-                settings.exposure_mode = Exposure_MEDIUM;
+                settings.camera_exposure = 0.5f;
             } else if (strcmp(argv[0], "high") == 0) {
-                settings.exposure_mode = Exposure_HIGH;
+                settings.camera_exposure = 1.f;
             } else {
                 usage(progname);
                 return 1;

--- a/src/utils/tracker_camera_calibration.cpp
+++ b/src/utils/tracker_camera_calibration.cpp
@@ -87,7 +87,7 @@ camera_calibration_main(int argc, char *argv[])
 
     PSMoveTracker *tracker = psmove_tracker_new();
     PSMOVE_VERIFY(tracker != nullptr, "Could not create tracker");
-    psmove_tracker_set_exposure(tracker, Exposure_HIGH);
+    psmove_tracker_set_exposure(tracker, 1.f);
 
     std::vector<std::vector<cv::Vec2f>> image_points;
     std::vector<std::vector<cv::Vec3f>> object_points;
@@ -225,7 +225,7 @@ verify_camera_calibration_main(int argc, char *argv[])
 
     PSMoveTracker *tracker = psmove_tracker_new();
     PSMOVE_VERIFY(tracker != nullptr, "Could not create tracker");
-    psmove_tracker_set_exposure(tracker, Exposure_HIGH);
+    psmove_tracker_set_exposure(tracker, 1.f);
 
     IplImage *image = capture_frame(tracker);
 


### PR DESCRIPTION
The tracker core codebase is quite old, this also tries to refactor parts of it (not all, though).

The new hue-based color calibration is faster and takes the environment into account (hues that appear more in the environment get penalized).

This has been developed over the holidays and refined with different lighting conditions, here's the hue-based color calibration with 4 controllers in low and high exposure modes:

[![Fast Hue Calibration](https://img.youtube.com/vi/ptP_zkRvAlE/0.jpg)](https://www.youtube.com/watch?v=ptP_zkRvAlE)

The blinking color calibration has also been updated to do per-color dimming. The cached color mappings (`colormapping.dat`) didn't work all that well in my tests, so they have been removed. The hue calibration is quite fast to do at every startup (see the video).

The `test_tracker` tool can be used to test both the blinking calibration ("B" key) and hue calibration ("H" key). If the hue calibration detects insufficient hues for all controllers, it falls back to blinking calibration.

Some things have been cleaned up, but there's always more that can be done here.