### PR TITLE
install psmove_config.h to include dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,7 @@ install(TARGETS ${PSMOVEAPI_INSTALL_TARGETS}
 )
 
 install(FILES ${PSMOVEAPI_HEADERS} DESTINATION include/psmoveapi)
+install(FILES ${CMAKE_BINARY_DIR}/psmove_config.h DESTINATION include/psmoveapi)
 install(FILES README.md COPYING DESTINATION share/psmoveapi)
 
 message("")


### PR DESCRIPTION
During psmoveapi build psmove_config.h is generated in ${CMAKE_BINARY_DIR} and is not installed along with other ${PSMOVEAPI_HEADERS}. This leads to compilation errors when something dependent on psmoveapi is built.