### PR TITLE
Changed 'Dropped frames' log level back down from WARNING to DEBUG

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -1463,7 +1463,7 @@ psmove_poll(PSMove *move)
          **/
         int seq = (move->input.common.buttons4 & 0x0F);
         if (seq != ((oldseq + 1) % 16)) {
-            PSMOVE_WARNING("Dropped frames (seq %d -> %d)", oldseq, seq);
+            PSMOVE_DEBUG("Dropped frames (seq %d -> %d)", oldseq, seq);
         }
 
         if (move->orientation_enabled) {


### PR DESCRIPTION
I don't know if this is necessarily still true with the newer move controllers, but with the older ones I have there is now a very large amount of 'dropped frames' log messages all the time with controllers connected.

Frames were always getting 'dropped' in this way before, but in https://github.com/thp/psmoveapi/commit/c9ee3b01b32f63ad5c5d12a76df7265b480b7523 "New logging macros" this particular log message changed from DEBUG, to WARNING, and is therefore now displayed in a default build of the api

As far as I can tell, the 'frame drops' were not, and are not causing any actual problems using the api, so it seems to me that either DEBUG feels like a more appropriate log level to use, or else it would make sense to do something else to reduce the unhelpfully large amount of spam.

(if this isn't the appropriate solution, I'd be happy to spend a bit of time working on a better one)
