### PR TITLE
Fix macOS CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,7 @@ jobs:
           - build_host: ubuntu-latest
             build_type: linux-native-gcc
           - build_host: macos-latest
-            build_type: macos-native-clang-x86_64
-          # Disabled until Github Actions gets support for M1 Macs.
-          # See also: https://github.com/actions/runner-images/issues/2187
-          #- build_host: macos-latest
-          #  build_type: macos-native-clang-arm64
+            build_type: macos-native-clang-arm64
           - build_host: windows-latest
             build_type: windows-native-msvc-x64
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         include:
           - build_host: ubuntu-latest
             build_type: linux-native-gcc
+          - build_host: macos-13
+            build_type: macos-native-clang-x86_64
           - build_host: macos-latest
             build_type: macos-native-clang-arm64
           - build_host: windows-latest

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -21,7 +21,7 @@ case "$UNAME" in
         brew update
         brew install --force cmake git libtool automake autoconf python libusb-compat sdl2 || true
         brew unlink libtool ; brew link --overwrite libtool
-        pip3 install --user sphinx
+        pip3 install --user --break-system-packages sphinx
         ;;
     MINGW64_NT-*)
         # Nothing to do, Windows OS


### PR DESCRIPTION
Let's just install Sphinx, and let's not worry about creating a special venv for now.

Also, Github uses arm64 runners now.