### PR TITLE
Add missing include

### DIFF
--- a/examples/c/test_navcon.cpp
+++ b/examples/c/test_navcon.cpp
@@ -34,6 +34,7 @@
 #include <limits.h>
 
 #include <algorithm>
+#include <cstring>
 
 #include "SDL.h"
 #include "psmove.h"


### PR DESCRIPTION
This fixes the following build issue with GCC 15

```
/builddir/build/BUILD/psmoveapi-4.0.12_20240424git26e1446-build/psmoveapi-26e1446fc9b5996192a1f406d289e64e4e97a195/examples/c/test_navcon.cpp:48:13: error: ‘strcmp’ was not declared in this scope
   48 |         if (strcmp(name, "Sony Navigation Controller") == 0) {
      |             ^~~~~~
/builddir/build/BUILD/psmoveapi-4.0.12_20240424git26e1446-build/psmoveapi-26e1446fc9b5996192a1f406d289e64e4e97a195/examples/c/test_navcon.cpp:40:1: note: ‘strcmp’ is defined in header ‘<cstring>’; this is probably fixable by adding ‘#include <cstring>’
   39 | #include "psmove.h"
  +++ |+#include <cstring>
   40 |
```