### PR TITLE
Fix the EventReceiver API (on Linux)

### DIFF
--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -94,13 +94,12 @@ static void
 on_monitor_update_moved(enum MonitorEvent event,
         enum MonitorEventDeviceType device_type,
         const char *path, const wchar_t *serial,
-        void *user_data)
+        unsigned short pid, void *user_data)
 {
     move_daemon *moved = static_cast<move_daemon *>(user_data);
 
-    if (event == EVENT_ZCM1_ADDED || event == EVENT_ZCM2_ADDED) {
+    if (event == EVENT_DEVICE_ADDED) {
         if (device_type == EVENT_DEVICE_TYPE_USB) {
-            unsigned short pid = event == EVENT_ZCM1_ADDED ? PSMOVE_PID : PSMOVE_PS4_PID;
             PSMove *move = psmove_connect_internal(serial, path, -1, pid);
             if (psmove_pair(move)) {
                 // Indicate to the user that pairing was successful

--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -98,12 +98,9 @@ on_monitor_update_moved(enum MonitorEvent event,
 {
     move_daemon *moved = static_cast<move_daemon *>(user_data);
 
-    if (event == EVENT_DEVICE_ADDED) {
+    if (event == EVENT_ZCM1_ADDED || event == EVENT_ZCM2_ADDED) {
         if (device_type == EVENT_DEVICE_TYPE_USB) {
-            // TODO: FIXME: This should use the device's actual USB product ID.
-            // HACK: We rely on this invalid PID being translated to a
-            //       valid controller model (the old ZCM1, by default).
-            unsigned short pid = 0;
+            unsigned short pid = event == EVENT_ZCM1_ADDED ? PSMOVE_PID : PSMOVE_PS4_PID;
             PSMove *move = psmove_connect_internal(serial, path, -1, pid);
             if (psmove_pair(move)) {
                 // Indicate to the user that pairing was successful

--- a/src/daemon/moved_monitor.h
+++ b/src/daemon/moved_monitor.h
@@ -37,8 +37,7 @@ extern "C" {
 #include <wchar.h>
 
 enum MonitorEvent {
-    EVENT_ZCM1_ADDED,
-    EVENT_ZCM2_ADDED,
+    EVENT_DEVICE_ADDED,
     EVENT_DEVICE_REMOVED,
 };
 
@@ -48,9 +47,10 @@ enum MonitorEventDeviceType {
     EVENT_DEVICE_TYPE_UNKNOWN,
 };
 
+// pid is the product ID on connect, it may be 0 on disconnect
 typedef void (*moved_event_callback)(enum MonitorEvent event,
         enum MonitorEventDeviceType device_type, const char *path,
-        const wchar_t *serial, void *user_data);
+        const wchar_t *serial, unsigned short pid, void *user_data);
 
 typedef struct _moved_monitor moved_monitor;
 

--- a/src/daemon/moved_monitor.h
+++ b/src/daemon/moved_monitor.h
@@ -37,7 +37,8 @@ extern "C" {
 #include <wchar.h>
 
 enum MonitorEvent {
-    EVENT_DEVICE_ADDED,
+    EVENT_ZCM1_ADDED,
+    EVENT_ZCM2_ADDED,
     EVENT_DEVICE_REMOVED,
 };
 

--- a/src/daemon/moved_monitor_linux.c
+++ b/src/daemon/moved_monitor_linux.c
@@ -158,8 +158,8 @@ _moved_monitor_handle_device(moved_monitor *monitor, struct udev_device *dev)
                     device_type = EVENT_DEVICE_TYPE_USB;
                 }
 
-                monitor->event_callback(product_id == PSMOVE_PID ? EVENT_ZCM1_ADDED : EVENT_ZCM2_ADDED, device_type, path,
-                        serial_number, monitor->event_callback_user_data);
+                monitor->event_callback(EVENT_DEVICE_ADDED, device_type, path,
+                        serial_number, product_id, monitor->event_callback_user_data);
             }
 
             free(serial_number);
@@ -170,7 +170,7 @@ _moved_monitor_handle_device(moved_monitor *monitor, struct udev_device *dev)
         free(uevent);
     } else if (strcmp(action, "remove") == 0) {
         monitor->event_callback(EVENT_DEVICE_REMOVED, device_type, path,
-                NULL, monitor->event_callback_user_data);
+                NULL, 0, monitor->event_callback_user_data);
     }
 }
 

--- a/src/daemon/moved_monitor_linux.c
+++ b/src/daemon/moved_monitor_linux.c
@@ -158,7 +158,7 @@ _moved_monitor_handle_device(moved_monitor *monitor, struct udev_device *dev)
                     device_type = EVENT_DEVICE_TYPE_USB;
                 }
 
-                monitor->event_callback(EVENT_DEVICE_ADDED, device_type, path,
+                monitor->event_callback(product_id == PSMOVE_PID ? EVENT_ZCM1_ADDED : EVENT_ZCM2_ADDED, device_type, path,
                         serial_number, monitor->event_callback_user_data);
             }
 

--- a/src/daemon/moved_monitor_osx.mm
+++ b/src/daemon/moved_monitor_osx.mm
@@ -119,7 +119,7 @@ private:
     static void on_device_matching(void *context, IOReturn result, void *sender, IOHIDDeviceRef device)
     {
         _moved_monitor *monitor = (_moved_monitor *)(context);
-        monitor->make_event(EVENT_DEVICE_ADDED, device);
+        monitor->make_event(get_product_id(device) == PSMOVE_PID ? EVENT_ZCM1_ADDED : EVENT_ZCM2_ADDED, device);
     }
 
     static void on_device_removal(void *context, IOReturn result, void *sender, IOHIDDeviceRef device)

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -70,7 +70,7 @@ struct PSMoveAPI {
 
     void update();
 
-    static void on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType device_type, const char *path, const wchar_t *serial, void *user_data);
+    static void on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType device_type, const char *path, const wchar_t *serial, unsigned short pid, void *user_data);
 
     EventReceiver *receiver;
     void *user_data;
@@ -290,16 +290,14 @@ PSMoveAPI::update()
 }
 
 void
-PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType device_type, const char *path, const wchar_t *serial, void *user_data)
+PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType device_type, const char *path, const wchar_t *serial, unsigned short pid, void *user_data)
 {
     auto self = static_cast<PSMoveAPI *>(user_data);
 
     switch (event) {
-        case EVENT_ZCM1_ADDED:
-        case EVENT_ZCM2_ADDED:
+        case EVENT_DEVICE_ADDED:
             {
-                PSMOVE_DEBUG("on_monitor_event(event=%s, device_type=0x%08x, path=\"%s\", serial=%p)",
-                       event == EVENT_ZCM1_ADDED ? "EVENT_ZCM1_ADDED" : "EVENT_ZCM2_ADDED",
+                PSMOVE_DEBUG("on_monitor_event(event=EVENT_DEVICE_ADDED, device_type=0x%08x, path=\"%s\", serial=%p)",
                        device_type, path, serial);
 
                 for (auto &c: self->controllers) {
@@ -310,7 +308,6 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
                     }
                 }
 
-                unsigned short pid = event == EVENT_ZCM1_ADDED ? PSMOVE_PID : PSMOVE_PS4_PID;
                 PSMove *move = psmove_connect_internal(serial, path, -1, pid);
                 if (move == nullptr) {
                     PSMOVE_ERROR("Cannot open move for retrieving serial!");

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -295,9 +295,11 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
     auto self = static_cast<PSMoveAPI *>(user_data);
 
     switch (event) {
-        case EVENT_DEVICE_ADDED:
+        case EVENT_ZCM1_ADDED:
+        case EVENT_ZCM2_ADDED:
             {
-                PSMOVE_DEBUG("on_monitor_event(event=EVENT_DEVICE_ADDED, device_type=0x%08x, path=\"%s\", serial=%p)",
+                PSMOVE_DEBUG("on_monitor_event(event=%s, device_type=0x%08x, path=\"%s\", serial=%p)",
+                       event == EVENT_ZCM1_ADDED ? "EVENT_ZCM1_ADDED" : "EVENT_ZCM2_ADDED",
                        device_type, path, serial);
 
                 for (auto &c: self->controllers) {
@@ -308,10 +310,7 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
                     }
                 }
 
-                // TODO: FIXME: This should use the device's actual USB product ID.
-                // HACK: We rely on this invalid PID being translated to a
-                //       valid controller model (the old ZCM1, by default).
-                unsigned short pid = 0;
+                unsigned short pid = event == EVENT_ZCM1_ADDED ? PSMOVE_PID : PSMOVE_PS4_PID;
                 PSMove *move = psmove_connect_internal(serial, path, -1, pid);
                 if (move == nullptr) {
                     PSMOVE_ERROR("Cannot open move for retrieving serial!");

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -97,7 +97,7 @@ on_monitor_update_pair(enum MonitorEvent event,
         const char *path, const wchar_t *serial,
         void *user_data)
 {
-    if (event == EVENT_DEVICE_ADDED) {
+    if (event == EVENT_ZCM1_ADDED || event == EVENT_ZCM2_ADDED) {
         if (device_type == EVENT_DEVICE_TYPE_USB) {
             pair(NULL);
         }

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -95,9 +95,9 @@ static void
 on_monitor_update_pair(enum MonitorEvent event,
         enum MonitorEventDeviceType device_type,
         const char *path, const wchar_t *serial,
-        void *user_data)
+        unsigned short pid, void *user_data)
 {
-    if (event == EVENT_ZCM1_ADDED || event == EVENT_ZCM2_ADDED) {
+    if (event == EVENT_DEVICE_ADDED) {
         if (device_type == EVENT_DEVICE_TYPE_USB) {
             pair(NULL);
         }


### PR DESCRIPTION
Split `EVENT_DEVICE_ADDED` into `EVENT_ZCM1_ADDED` and `EVENT_ZCM2_ADDED` so the proper product ID can be used, this removes two FIXMEs and makes it work on Linux (NOT tested on OSX/windows, no code changes were needed on windows, and the OSX code changes were relatively simple)