### PR TITLE
Fix minor problems caught by valgrind

### DIFF
--- a/src/psmove.c
+++ b/src/psmove.c
@@ -565,7 +565,9 @@ psmove_connect_internal(const wchar_t *serial, const char *path, int id, unsigne
         if (move->connection_type == Conn_Unknown) {
             move->connection_type = Conn_USB;
         }
-        move->serial_number = psmove_get_serial(move);
+        char* new_serial = psmove_get_serial(move);
+        free(move->serial_number);
+        move->serial_number = new_serial;
     }
 
     // Recently disconnected controllers might still show up in hidapi (especially Windows).

--- a/src/psmove.c
+++ b/src/psmove.c
@@ -916,7 +916,7 @@ psmove_connect()
 int
 _psmove_read_btaddrs(PSMove *move, PSMove_Data_BTAddr *host, PSMove_Data_BTAddr *controller)
 {
-    unsigned char btg[PSMOVE_MAX_BTADDR_GET_SIZE];
+    unsigned char btg[PSMOVE_MAX_BTADDR_GET_SIZE] = {0};
     size_t report_size = PSMOVE_BTADDR_GET_SIZE;
     int res;
 


### PR DESCRIPTION
This contains fixes for the two issues I ran into when running under Valgrind. The memory leak is straightforwardly a memory leak. The uninitialized data is maybe a false positive? I don't know enough about the details to make a call, but initializing to 0 makes valgrind happy, maybe fixes a real bug and is negligible cost.