### PR TITLE
Allow disabling vendoring.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,20 @@ cmake_minimum_required(VERSION 3.16)
 
 project(PSMoveAPI)
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/hidapi/hidapi/hidapi.h")
-    message(FATAL_ERROR "hidapi not found, did you forget to run 'git submodule update --init'?")
-endif()
+option(PSMOVEAPI_VENDORING "Vendor dependencies" ON)
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/libusb-1.0/libusb/libusb.h")
-    message(FATAL_ERROR "libusb not found, did you forget to run 'git submodule update --init'?")
-endif()
+if (PSMOVEAPI_VENDORING)
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/hidapi/hidapi/hidapi.h")
+        message(FATAL_ERROR "hidapi not found, did you forget to run 'git submodule update --init'?")
+    endif()
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/PS3EYEDriver/src/ps3eye.h")
-    message(FATAL_ERROR "PS3EYEDriver not found, did you forget to run 'git submodule update --init'?")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/libusb-1.0/libusb/libusb.h")
+        message(FATAL_ERROR "libusb not found, did you forget to run 'git submodule update --init'?")
+    endif()
+
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/PS3EYEDriver/src/ps3eye.h")
+        message(FATAL_ERROR "PS3EYEDriver not found, did you forget to run 'git submodule update --init'?")
+    endif()
 endif()
 
 # get rid of Visual Studio's default "Debug" and "Release" output directories

--- a/cmake/FindUSB1.cmake
+++ b/cmake/FindUSB1.cmake
@@ -21,6 +21,9 @@ IF (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
     set(LIBUSB_FOUND TRUE)
 
 ELSE (LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+    IF (NOT PSMOVEAPI_VENDORING)
+        message(FATAL_ERROR "libusb was not found and vendoring is disabled")
+    ENDIF()
     # Because we want to use the static library,
     # look locally only.
     find_path(LIBUSB_INCLUDE_DIR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,11 @@ set(PSMOVEAPI_PLATFORM_SRC)    # Container for source files
 set(PSMOVEAPI_INSTALL_TARGETS) # Container for build targets to be installed
 set(PSMOVEAPI_MATH_SRC)        # Container for math related source files
 
-include_directories(${ROOT_DIR}/external/hidapi/hidapi)
-include_directories(${ROOT_DIR}/external/glm)
+
+IF(PSMOVEAPI_VENDORING)
+    include_directories(${ROOT_DIR}/external/hidapi/hidapi)
+    include_directories(${ROOT_DIR}/external/glm)
+ENDIF()
 include_directories(${CMAKE_BINARY_DIR})
 
 set(INFO_LICENSE "BSD")
@@ -54,7 +57,11 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(APPEND PSMOVEAPI_REQUIRED_LIBS ${COREFOUNDATION})
     list(APPEND PSMOVEAPI_REQUIRED_LIBS ${IOBLUETOOTH})
 
-    set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/mac/hid.c)
+    IF(PSMOVEAPI_VENDORING)
+        set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/mac/hid.c)
+    ELSE()
+        message(FATAL_ERROR "disabling vendoring is currently not supported for ${CMAKE_SYSTEM_NAME}")
+    ENDIF()
 
     list(APPEND PSMOVEAPI_PLATFORM_SRC
         ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_osx.mm)
@@ -69,7 +76,11 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     list(APPEND PSMOVEAPI_REQUIRED_LIBS setupapi bthprops kernel32 ws2_32 winmm version imm32)
 
-    set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/windows/hid.c)
+    IF(PSMOVEAPI_VENDORING)
+        set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/windows/hid.c)
+    ELSE()
+        message(FATAL_ERROR "disabling vendoring is currently not supported for ${CMAKE_SYSTEM_NAME}")
+    ENDIF()
 
     list(APPEND PSMOVEAPI_PLATFORM_SRC
         ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_windows.c)
@@ -93,7 +104,17 @@ ELSE()
     include_directories(${BLUEZ_INCLUDE_DIRS})
     list(APPEND PSMOVEAPI_REQUIRED_LIBS ${BLUEZ_LIBRARIES})
 
-    set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/linux/hid.c)
+    IF(PSMOVEAPI_VENDORING)
+        set(HIDAPI_SRC ${ROOT_DIR}/external/hidapi/linux/hid.c)
+    ELSE()
+        pkg_check_modules(HIDAPI REQUIRED hidapi-hidraw)
+        include_directories(${HIDAPI_INCLUDE_DIRS})
+        list(APPEND PSMOVEAPI_REQUIRED_LIBS hidapi-hidraw)
+
+        pkg_check_modules(GLM REQUIRED glm)
+        include_directories(${GLM_INCLUDE_DIRS})
+        list(APPEND PSMOVEAPI_REQUIRED_LIBS ${GLM_LIBRARIES})
+    ENDIF()
 
     list(APPEND PSMOVEAPI_PLATFORM_SRC
         ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_linux.cpp)

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -16,6 +16,9 @@ option(PSMOVE_USE_DEBUG_CAPTURE "Always show camera capture input" OFF)
 
 
 IF(PSMOVE_USE_PS3EYE_DRIVER)
+    IF(NOT PSMOVEAPI_VENDORING)
+        message(FATAL_ERROR "disabling vendoring is currently not supported for PS3EYEDriver")
+    ENDIF()
     # PS3EYEDriver is based on GPL'd code
     set(INFO_LICENSE "GPL")
 


### PR DESCRIPTION
psmoveapi ships its own version of PS3EYEDriver, glm, hidapi and libusb-1.0. It is often desirable for downstream maintainers to use their own version of these packages. However the psmoveapi CMake configuration currently does not allow that.

This change introduces a new `PSMOVEAPI_VENDORING` CMake variable which is enabled by default. When it is disabled, we disable all references to the `external/` directory across the build system and we let CMake look for its dependencies in the usual locations.

This is still explicitly broken for Windows and Darwin as I have no access to such systems and am not able to test whether this works.

Successfully tested on Debian 12.13:

```
$ mkdir build && cd build && cmake -DPSMOVEAPI_VENDORING=OFF ..
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Checking for module 'dbus-1'
--   Found dbus-1, version 1.14.10
-- Checking for module 'libudev'
--   Found libudev, version 252
-- Checking for module 'bluez>=5'
--   Found bluez, version 5.66
-- Checking for module 'hidapi-hidraw'
--   Found hidapi-hidraw, version 0.13.1
-- Checking for module 'glm'
--   Found glm, version 0.9.9.8

  Tracker
    Tracker library:       Yes (OpenCV version 4.6.0)
    Camera control driver: V4L2

  Build configuration
    Debug build:      No
    Library license:  BSD (see README.md for details)

  Additional targets
    C example apps:   Yes
    NavCon test:      Yes (using SDL2 joystick API)

-- Configuring done
-- Generating done
-- Build files have been written to: build
$ make
[  3%] Building C object CMakeFiles/psmoveapi.dir/src/psmove.c.o
[  6%] Building C object CMakeFiles/psmoveapi.dir/src/psmove_calibration.c.o
[  9%] Building CXX object CMakeFiles/psmoveapi.dir/src/psmove_orientation.cpp.o
[ 12%] Building CXX object CMakeFiles/psmoveapi.dir/src/psmoveapi.cpp.o
[ 16%] Building C object CMakeFiles/psmoveapi.dir/src/daemon/moved_monitor_linux.c.o
[ 19%] Building CXX object CMakeFiles/psmoveapi.dir/src/daemon/moved_client.cpp.o
[ 22%] Building CXX object CMakeFiles/psmoveapi.dir/src/platform/psmove_port_linux.cpp.o
[ 25%] Building CXX object CMakeFiles/psmoveapi.dir/src/math/psmove_alignment.cpp.o
[ 29%] Building C object CMakeFiles/psmoveapi.dir/src/math/psmove_math.c.o
[ 32%] Building CXX object CMakeFiles/psmoveapi.dir/src/math/psmove_quaternion.cpp.o
[ 35%] Building C object CMakeFiles/psmoveapi.dir/src/math/psmove_vector.c.o
[ 38%] Linking CXX shared library libpsmoveapi.so
[ 38%] Built target psmoveapi
[ 41%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/psmove_tracker_hue_calibration.cpp.o
[ 45%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/psmove_tracker.cpp.o
[ 48%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/psmove_fusion.cpp.o
[ 51%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/tracker_helpers.cpp.o
[ 54%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/camera_control.cpp.o
[ 58%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/camera_control_driver.cpp.o
[ 61%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/camera_control_layouts.cpp.o
[ 64%] Building CXX object CMakeFiles/psmoveapi_tracker.dir/src/tracker/camera_control_driver_v4l2.cpp.o
[ 67%] Linking CXX shared library libpsmoveapi_tracker.so
[ 67%] Built target psmoveapi_tracker
[ 70%] Building CXX object CMakeFiles/psmove.dir/src/utils/psmovecli.cpp.o
[ 74%] Linking CXX executable psmove
[ 74%] Built target psmove
[ 77%] Building C object CMakeFiles/example.dir/examples/c/example.c.o
[ 80%] Linking C executable example
[ 80%] Built target example
[ 83%] Building C object CMakeFiles/multiple.dir/examples/c/multiple.c.o
[ 87%] Linking C executable multiple
[ 87%] Built target multiple
[ 90%] Building CXX object CMakeFiles/example_new_api.dir/examples/c/example_new_api.cpp.o
[ 93%] Linking CXX executable example_new_api
[ 93%] Built target example_new_api
[ 96%] Building CXX object CMakeFiles/test_navcon.dir/examples/c/test_navcon.cpp.o
[100%] Linking CXX executable test_navcon
[100%] Built target test_navcon
```

As per https://github.com/thp/psmoveapi/issues/510