### PR TITLE
linux: include <poll.h> instead of <sys/poll.h>.

### DIFF
--- a/src/psmove_port.h
+++ b/src/psmove_port.h
@@ -41,7 +41,7 @@
 #ifdef __linux
 #  include <unistd.h>
 #  include <linux/limits.h>
-#  include <sys/poll.h>
+#  include <poll.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The <sys/poll.h> header is an old deprecated reference to the POSIX <poll.h> header. This works fine with the GNU C Library but musl libc emits a [warning](https://git.musl-libc.org/cgit/musl/commit/?id=54446d730cfb17c5f7bcf57f139458678f5066cc) when we refer to <sys/poll.h> insted of <poll.h>.

This change updates the reference on Linux to use the new name.