### PR TITLE
Fix pkg-config lookup for libusb to libsub-1.0 on Linux

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
   if (PSMOVE_USE_SIXPAIR)
     # sixpair needs libusb
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(LIBUSB REQUIRED libusb QUIET)
+    pkg_check_modules(LIBUSB REQUIRED libusb-1.0 QUIET)
     include_directories(${LIBUSB_INCLUDE_DIRS})
     target_link_libraries(psmove ${LIBUSB_LIBRARIES})
   endif()


### PR DESCRIPTION
On modern Linux distributions (Ubuntu 24.04+, Debian, Fedora, etc.), the pkg-config module is named libusb-1.0 instead of libusb.

That makes to the OS not founding the libusb dependency

This change modifies the line
pkg_check_modules(LIBUSB REQUIRED libusb QUIET)
with
pkg_check_modules(LIBUSB REQUIRED libusb-1.0 QUIET)