### PR TITLE
camera-firmware: fix firmware upload on macOS

### DIFF
--- a/src/utils/ps4_camera_firmware.cpp
+++ b/src/utils/ps4_camera_firmware.cpp
@@ -104,8 +104,21 @@ upload_firmware(libusb_context *context, libusb_device *dev, const std::vector<c
     int res;
 
     PSMOVE_VERIFY((res = libusb_open(dev, &handle)) == 0, "res = %d", res);
+#if !defined(__APPLE__)
+    // On macOS, libusb_reset_device() triggers a re-enumeration that drops
+    // the device off the bus and invalidates the handle, so skip it there.
     PSMOVE_VERIFY((res = libusb_reset_device(handle)) == 0, "res = %d", res);
-    PSMOVE_VERIFY((res = libusb_set_configuration(handle, 1)) == 0, "res = %d", res);
+#endif
+    res = libusb_set_configuration(handle, 1);
+#if defined(__APPLE__)
+    // macOS already selects configuration 1 via AppleUSBHostCompositeDevice;
+    // tolerate a set_configuration failure as long as we can claim interface 0.
+    if (res != 0) {
+        PSMOVE_WARNING("libusb_set_configuration failed (res = %d), continuing", res);
+    }
+#else
+    PSMOVE_VERIFY(res == 0, "res = %d", res);
+#endif
     PSMOVE_VERIFY((res = libusb_claim_interface(handle, 0)) == 0, "res = %d", res);
 
     static constexpr const size_t CHUNK_SIZE = 512;
@@ -220,10 +233,12 @@ Optional parameters:
             const char *model = nullptr;
 
             libusb_device *parent_dev = libusb_get_parent(dev);
-            struct libusb_device_descriptor pdesc;
-            libusb_get_device_descriptor(parent_dev, &pdesc);
+            struct libusb_device_descriptor pdesc = {};
+            if (parent_dev != nullptr) {
+                libusb_get_device_descriptor(parent_dev, &pdesc);
+            }
 
-            if (PS4_TO_PS5_ADAPTER_ID.matches(pdesc)) {
+            if (parent_dev != nullptr && PS4_TO_PS5_ADAPTER_ID.matches(pdesc)) {
                 model = "PS4 camera w/ PS4 Camera Adapter (CFI-ZAA1)";
                 camera_is_ps4 = true;
             } else if (camera_is_ps4) {


### PR DESCRIPTION
`psmove camera-firmware` was unusable on macOS due to two issues with the Darwin libusb backend:

## 1. Segfault from NULL parent device

`libusb_get_parent()` can return NULL on macOS. The result was passed unchecked to `libusb_get_device_descriptor()`, crashing the tool before the firmware upload could even start.

## 2. Upload aborted after device reset

`libusb_reset_device()` on the Darwin backend triggers a re-enumeration that drops the device off the bus and invalidates the handle, so the subsequent `libusb_set_configuration()` failed with `LIBUSB_ERROR_NO_DEVICE` (-4) and aborted the upload. This change skips the reset on macOS (the device is freshly enumerated in boot mode anyway) and tolerates a `set_configuration` failure there, since `AppleUSBHostCompositeDevice` already selects configuration 1.

## Testing

Apple Silicon (M4, macOS 26), Sony PS5 HD Camera (CFI-ZEY1) behind a USB 3 hub:

- Before: segfault on `psmove camera-firmware`; with only the NULL check fixed, upload aborted with `res = -4` at `libusb_set_configuration`.
- After both fixes: firmware upload completes ("Firmware uploaded") and the camera re-enumerates as a standard UVC device (`05a9:058c`, "USB Camera-OV580"), working in Photo Booth, QuickTime and Teams at 1920x1080@30.
- Linux/Windows code paths are unchanged (the guards only affect macOS behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)