### PR TITLE
Implement controller monitoring on Windows and fix Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             build_type: macos-native-clang-x86_64
           - build_host: macos-latest
             build_type: macos-native-clang-arm64
-          - build_host: windows-latest
+          - build_host: windows-2022
             build_type: windows-native-msvc-x64
     env:
       BUILD_TYPE: ${{ matrix.build_type }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ starting after version 4.0.12, but historic entries might not.
 
 ### Changed
 
+- Windows: `psmove pair -d` now waits for controller notifications instead of repeatedly rescanning
 - CI: Migrate from Travis CI (macOS, Linux), and AppVeyor (Windows) to Github Actions
 - Linux: Build OpenCV from source
 - `CMakeLists.txt`: Add check for 'git submodule init' (Fixes #352)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ starting after version 4.0.12, but historic entries might not.
 
 ### Added
 
+- Windows: Dynamically monitor ZCM1 and ZCM2 controller connections and disconnections
 - macOS: Add build support for M1/Apple Silicon (Fixes #440)
 - Linux/Debian: Force building tracker and test programs (Fixes #437)
 - Added `psmove_tracker_opencv.h` for OpenCV-specific functions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,9 @@ ELSEIF(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
     list(APPEND PSMOVEAPI_PLATFORM_SRC
         ${CMAKE_CURRENT_LIST_DIR}/platform/psmove_port_windows.c)
+
+    list(APPEND PSMOVEAPI_MOVED_SRC
+        ${CMAKE_CURRENT_LIST_DIR}/daemon/moved_monitor_windows.cpp)
 ELSE()
     # Linux
     find_package(PkgConfig REQUIRED)

--- a/src/daemon/moved_monitor.h
+++ b/src/daemon/moved_monitor.h
@@ -30,6 +30,8 @@
 
 
 
+#include "psmove.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,17 +56,25 @@ typedef void (*moved_event_callback)(enum MonitorEvent event,
 
 typedef struct _moved_monitor moved_monitor;
 
-moved_monitor *
-moved_monitor_new(moved_event_callback callback, void *user_data);
+ADDAPI moved_monitor *
+ADDCALL moved_monitor_new(moved_event_callback callback, void *user_data);
 
-void
-moved_monitor_poll(moved_monitor *monitor);
+#ifdef _WIN32
+// Block until Windows signals a device change or the fallback rescan is due.
+// Call moved_monitor_poll() after this returns to process any controller
+// additions or removals.
+ADDAPI void
+ADDCALL moved_monitor_wait(moved_monitor *monitor);
+#endif
 
-int
-moved_monitor_get_fd(moved_monitor *monitor);
+ADDAPI void
+ADDCALL moved_monitor_poll(moved_monitor *monitor);
 
-void
-moved_monitor_free(moved_monitor *monitor);
+ADDAPI int
+ADDCALL moved_monitor_get_fd(moved_monitor *monitor);
+
+ADDAPI void
+ADDCALL moved_monitor_free(moved_monitor *monitor);
 
 #ifdef __cplusplus
 }

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -53,6 +53,17 @@ namespace {
 const ULONGLONG RESCAN_INTERVAL_MS = 500;
 
 struct MoveDevice {
+    MoveDevice(const char *device_path, const wchar_t *device_serial,
+            unsigned short device_product_id)
+        : path(device_path)
+        , serial(device_serial == nullptr ? L"" : device_serial)
+        , product_id(device_product_id)
+        , device_type(serial.size() > 1
+                ? EVENT_DEVICE_TYPE_BLUETOOTH
+                : EVENT_DEVICE_TYPE_USB)
+    {
+    }
+
     std::string path;
     std::wstring serial;
     unsigned short product_id;
@@ -85,6 +96,11 @@ lowercase(std::wstring value)
 bool
 replace_once(std::string &value, const char *from, const char *to)
 {
+    if (from == nullptr || to == nullptr) {
+        PSMOVE_WARNING("nullptr value in replace_once()");
+        return false;
+    }
+
     const auto position = value.find(from);
     if (position == std::string::npos) {
         return false;
@@ -97,10 +113,16 @@ bool
 contains_device_identifier(const std::wstring &path, const wchar_t *format,
         unsigned short identifier)
 {
+    if (format == nullptr) {
+        PSMOVE_WARNING("nullptr format in contains_device_identifier()");
+        return false;
+    }
+
     // Windows embeds VID/PID values in symbolic paths using fragments such as
     // "vid_054c" or "vid&0002054c". Format the shared numeric identifier into
     // the requested path fragment before searching the normalized path.
     wchar_t value[16] = {};
+    // Use std::size(value) here once the project requires C++17.
     const auto length = std::swprintf(
             value,
             sizeof(value) / sizeof(value[0]),
@@ -121,36 +143,25 @@ is_move_interface_path(const wchar_t *path)
     const auto normalized = lowercase(std::wstring(path));
     // Accept both Windows VID/PID path formats and both Move generations:
     // ZCM1 (03d5) and ZCM2 (0c5e).
-    const bool sony =
-            contains_device_identifier(normalized, L"vid_%04x", PSMOVE_VID) ||
-            contains_device_identifier(normalized, L"vid&0002%04x", PSMOVE_VID);
-    const bool move =
-            contains_device_identifier(normalized, L"pid_%04x", PSMOVE_PID) ||
+    if (!contains_device_identifier(normalized, L"vid_%04x", PSMOVE_VID) &&
+            !contains_device_identifier(
+                    normalized, L"vid&0002%04x", PSMOVE_VID)) {
+        return false;
+    }
+
+    return contains_device_identifier(normalized, L"pid_%04x", PSMOVE_PID) ||
             contains_device_identifier(normalized, L"pid&%04x", PSMOVE_PID) ||
-            contains_device_identifier(normalized, L"pid_%04x", PSMOVE_PS4_PID) ||
-            contains_device_identifier(normalized, L"pid&%04x", PSMOVE_PS4_PID);
-    return sony && move;
+            contains_device_identifier(
+                    normalized, L"pid_%04x", PSMOVE_PS4_PID) ||
+            contains_device_identifier(
+                    normalized, L"pid&%04x", PSMOVE_PS4_PID);
 }
 
 MoveDevices
 enumerate_move_devices()
 {
-    struct Candidate {
-        Candidate(const char *candidate_path, const wchar_t *candidate_serial,
-                unsigned short candidate_product_id)
-            : path(candidate_path)
-            , serial(candidate_serial == nullptr ? L"" : candidate_serial)
-            , product_id(candidate_product_id)
-        {
-        }
-
-        std::string path;
-        std::wstring serial;
-        unsigned short product_id;
-    };
-
     std::set<std::string> all_paths;
-    std::vector<Candidate> candidates;
+    std::vector<MoveDevice> candidates;
     const unsigned short product_ids[] = {PSMOVE_PID, PSMOVE_PS4_PID};
 
     for (const auto product_id : product_ids) {
@@ -187,16 +198,7 @@ enumerate_move_devices()
             continue;
         }
 
-        result.emplace(normalized_path, MoveDevice{
-            candidate.path,
-            candidate.serial,
-            candidate.product_id,
-            // Windows exposes the controller serial over Bluetooth, while
-            // the USB interface has no usable serial.
-            candidate.serial.size() > 1
-                    ? EVENT_DEVICE_TYPE_BLUETOOTH
-                    : EVENT_DEVICE_TYPE_USB,
-        });
+        result.emplace(normalized_path, candidate);
     }
     return result;
 }

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -215,6 +215,7 @@ struct _moved_monitor {
 
     HMODULE cfgmgr32;
     HCMNOTIFICATION notification;
+    HANDLE device_event;
     CMUnregisterNotification unregister_notification;
 };
 
@@ -233,6 +234,9 @@ on_device_notification(HCMNOTIFICATION, PVOID context,
             action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) &&
             is_move_interface_path(event_data->u.DeviceInterface.SymbolicLink)) {
         monitor->rescan_requested.store(true);
+        if (monitor->device_event != nullptr) {
+            SetEvent(monitor->device_event);
+        }
     }
     return ERROR_SUCCESS;
 }
@@ -246,6 +250,12 @@ moved_monitor_new(moved_event_callback callback, void *user_data)
     monitor->event_callback_user_data = user_data;
     monitor->rescan_requested.store(true);
     monitor->next_rescan = GetTickCount64();
+    // The callback signals this auto-reset event so blocking callers wake
+    // without waiting for the periodic fallback rescan.
+    monitor->device_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (monitor->device_event == nullptr) {
+        PSMOVE_WARNING("Could not create Windows device notification event");
+    }
     // Load notifications dynamically so monitoring still works through the
     // periodic rescan when the API is unavailable.
     monitor->cfgmgr32 = LoadLibraryW(L"CfgMgr32.dll");
@@ -291,6 +301,36 @@ moved_monitor_get_fd(moved_monitor *)
 {
     // Windows notifications arrive through a callback instead of a pollable fd.
     return -1;
+}
+
+void
+moved_monitor_wait(moved_monitor *monitor)
+{
+    psmove_return_if_fail(monitor != nullptr);
+
+    const auto now = GetTickCount64();
+    if (monitor->rescan_requested.load() || now >= monitor->next_rescan) {
+        return;
+    }
+
+    const auto remaining = monitor->next_rescan - now;
+    const auto timeout = remaining > MAXDWORD
+            ? MAXDWORD
+            : static_cast<DWORD>(remaining);
+
+    if (monitor->device_event == nullptr) {
+        Sleep(timeout);
+        return;
+    }
+
+    // The notification callback signals the event immediately. The timeout
+    // preserves periodic rescanning if Windows misses a notification.
+    const auto result = WaitForSingleObject(monitor->device_event, timeout);
+    if (result == WAIT_FAILED) {
+        PSMOVE_WARNING(
+                "Could not wait for Windows device notification (%lu)",
+                static_cast<unsigned long>(GetLastError()));
+    }
 }
 
 
@@ -350,6 +390,9 @@ moved_monitor_free(moved_monitor *monitor)
     }
     if (monitor->cfgmgr32 != nullptr) {
         FreeLibrary(monitor->cfgmgr32);
+    }
+    if (monitor->device_event != nullptr) {
+        CloseHandle(monitor->device_event);
     }
     delete monitor;
 }

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -1,6 +1,7 @@
 /**
  * PS Move API - An interface for the PS Move Motion Controller
  * Copyright (c) 2012 Thomas Perl <m@thp.io>
+ * Copyright (c) 2026 Aaron Angert
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +34,7 @@
 #include <atomic>
 #include <cctype>
 #include <cstring>
+#include <cwchar>
 #include <cwctype>
 #include <map>
 #include <set>
@@ -92,6 +94,22 @@ replace_once(std::string &value, const char *from, const char *to)
 }
 
 bool
+contains_device_identifier(const std::wstring &path, const wchar_t *format,
+        unsigned short identifier)
+{
+    // Windows embeds VID/PID values in symbolic paths using fragments such as
+    // "vid_054c" or "vid&0002054c". Format the shared numeric identifier into
+    // the requested path fragment before searching the normalized path.
+    wchar_t value[16] = {};
+    const auto length = std::swprintf(
+            value,
+            sizeof(value) / sizeof(value[0]),
+            format,
+            static_cast<unsigned int>(identifier));
+    return length > 0 && path.find(value) != std::wstring::npos;
+}
+
+bool
 is_move_interface_path(const wchar_t *path)
 {
     if (path == nullptr) {
@@ -103,12 +121,14 @@ is_move_interface_path(const wchar_t *path)
     const auto normalized = lowercase(std::wstring(path));
     // Accept both Windows VID/PID path formats and both Move generations:
     // ZCM1 (03d5) and ZCM2 (0c5e).
-    const bool sony = normalized.find(L"vid_054c") != std::wstring::npos ||
-            normalized.find(L"vid&0002054c") != std::wstring::npos;
-    const bool move = normalized.find(L"pid_03d5") != std::wstring::npos ||
-            normalized.find(L"pid&03d5") != std::wstring::npos ||
-            normalized.find(L"pid_0c5e") != std::wstring::npos ||
-            normalized.find(L"pid&0c5e") != std::wstring::npos;
+    const bool sony =
+            contains_device_identifier(normalized, L"vid_%04x", PSMOVE_VID) ||
+            contains_device_identifier(normalized, L"vid&0002%04x", PSMOVE_VID);
+    const bool move =
+            contains_device_identifier(normalized, L"pid_%04x", PSMOVE_PID) ||
+            contains_device_identifier(normalized, L"pid&%04x", PSMOVE_PID) ||
+            contains_device_identifier(normalized, L"pid_%04x", PSMOVE_PS4_PID) ||
+            contains_device_identifier(normalized, L"pid&%04x", PSMOVE_PS4_PID);
     return sony && move;
 }
 
@@ -116,6 +136,14 @@ MoveDevices
 enumerate_move_devices()
 {
     struct Candidate {
+        Candidate(const char *candidate_path, const wchar_t *candidate_serial,
+                unsigned short candidate_product_id)
+            : path(candidate_path)
+            , serial(candidate_serial == nullptr ? L"" : candidate_serial)
+            , product_id(candidate_product_id)
+        {
+        }
+
         std::string path;
         std::wstring serial;
         unsigned short product_id;
@@ -140,11 +168,10 @@ enumerate_move_devices()
                 continue;
             }
 
-            candidates.push_back({
+            candidates.emplace_back(
                 device->path,
-                device->serial_number == nullptr ? L"" : device->serial_number,
-                product_id,
-            });
+                device->serial_number,
+                product_id);
         }
         hid_free_enumeration(devices);
     }
@@ -223,26 +250,34 @@ moved_monitor_new(moved_event_callback callback, void *user_data)
     monitor->notification = nullptr;
     monitor->unregister_notification = nullptr;
 
-    if (monitor->cfgmgr32 != nullptr) {
-        auto register_notification = reinterpret_cast<CMRegisterNotification>(
-                GetProcAddress(monitor->cfgmgr32, "CM_Register_Notification"));
-        monitor->unregister_notification = reinterpret_cast<CMUnregisterNotification>(
-                GetProcAddress(monitor->cfgmgr32, "CM_Unregister_Notification"));
+    if (monitor->cfgmgr32 == nullptr) {
+        PSMOVE_WARNING("Could not load CfgMgr32.dll; using periodic HID rescans");
+        return monitor;
+    }
 
-        if (register_notification != nullptr &&
-                monitor->unregister_notification != nullptr) {
-            CM_NOTIFY_FILTER filter = {};
-            filter.cbSize = sizeof(filter);
-            filter.Flags = CM_NOTIFY_FILTER_FLAG_ALL_INTERFACE_CLASSES;
-            filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
-            const auto result = register_notification(
-                    &filter, monitor, on_device_notification, &monitor->notification);
-            if (result != CR_SUCCESS) {
-                monitor->notification = nullptr;
-                PSMOVE_WARNING("Could not register for Windows device notifications (0x%lx)",
-                        static_cast<unsigned long>(result));
-            }
-        }
+    auto register_notification = reinterpret_cast<CMRegisterNotification>(
+            GetProcAddress(monitor->cfgmgr32, "CM_Register_Notification"));
+    monitor->unregister_notification = reinterpret_cast<CMUnregisterNotification>(
+            GetProcAddress(monitor->cfgmgr32, "CM_Unregister_Notification"));
+
+    if (register_notification == nullptr ||
+            monitor->unregister_notification == nullptr) {
+        PSMOVE_WARNING(
+                "CfgMgr32 device notification functions are unavailable; "
+                "using periodic HID rescans");
+        return monitor;
+    }
+
+    CM_NOTIFY_FILTER filter = {};
+    filter.cbSize = sizeof(filter);
+    filter.Flags = CM_NOTIFY_FILTER_FLAG_ALL_INTERFACE_CLASSES;
+    filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+    const auto result = register_notification(
+            &filter, monitor, on_device_notification, &monitor->notification);
+    if (result != CR_SUCCESS) {
+        monitor->notification = nullptr;
+        PSMOVE_WARNING("Could not register for Windows device notifications (0x%lx)",
+                static_cast<unsigned long>(result));
     }
 
     return monitor;
@@ -306,6 +341,7 @@ moved_monitor_free(moved_monitor *monitor)
 {
     psmove_return_if_fail(monitor != nullptr);
 
+    // Notification setup can fail while periodic rescanning remains active.
     if (monitor->notification != nullptr &&
             monitor->unregister_notification != nullptr) {
         monitor->unregister_notification(monitor->notification);

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -1,0 +1,317 @@
+/**
+ * PS Move API - An interface for the PS Move Motion Controller
+ * Copyright (c) 2012 Thomas Perl <m@thp.io>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#include <windows.h>
+#include <cfgmgr32.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstring>
+#include <cwctype>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "hidapi.h"
+#include "moved_monitor.h"
+#include "../psmove_private.h"
+
+
+namespace {
+
+// Periodic rescans provide a fallback when a device notification is missed
+// or the notification API is unavailable.
+const ULONGLONG RESCAN_INTERVAL_MS = 500;
+
+struct MoveDevice {
+    std::string path;
+    std::wstring serial;
+    unsigned short product_id;
+    enum MonitorEventDeviceType device_type;
+};
+
+using MoveDevices = std::map<std::string, MoveDevice>;
+using CMRegisterNotification = CONFIGRET (WINAPI *)(
+        PCM_NOTIFY_FILTER, PVOID, PCM_NOTIFY_CALLBACK, PHCMNOTIFICATION);
+using CMUnregisterNotification = CONFIGRET (WINAPI *)(HCMNOTIFICATION);
+
+std::string
+lowercase(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+std::wstring
+lowercase(std::wstring value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](wchar_t c) {
+        return static_cast<wchar_t>(std::towlower(c));
+    });
+    return value;
+}
+
+bool
+replace_once(std::string &value, const char *from, const char *to)
+{
+    const auto position = value.find(from);
+    if (position == std::string::npos) {
+        return false;
+    }
+    value.replace(position, strlen(from), to);
+    return true;
+}
+
+bool
+is_move_interface_path(const wchar_t *path)
+{
+    if (path == nullptr) {
+        return false;
+    }
+
+    // Windows reports device interfaces as symbolic HID paths. Normalize the
+    // casing before matching the identifiers embedded in the path.
+    const auto normalized = lowercase(std::wstring(path));
+    // Accept both Windows VID/PID path formats and both Move generations:
+    // ZCM1 (03d5) and ZCM2 (0c5e).
+    const bool sony = normalized.find(L"vid_054c") != std::wstring::npos ||
+            normalized.find(L"vid&0002054c") != std::wstring::npos;
+    const bool move = normalized.find(L"pid_03d5") != std::wstring::npos ||
+            normalized.find(L"pid&03d5") != std::wstring::npos ||
+            normalized.find(L"pid_0c5e") != std::wstring::npos ||
+            normalized.find(L"pid&0c5e") != std::wstring::npos;
+    return sony && move;
+}
+
+MoveDevices
+enumerate_move_devices()
+{
+    struct Candidate {
+        std::string path;
+        std::wstring serial;
+        unsigned short product_id;
+    };
+
+    std::set<std::string> all_paths;
+    std::vector<Candidate> candidates;
+    const unsigned short product_ids[] = {PSMOVE_PID, PSMOVE_PS4_PID};
+
+    for (const auto product_id : product_ids) {
+        auto devices = hid_enumerate(PSMOVE_VID, product_id);
+        for (auto device = devices; device != nullptr; device = device->next) {
+            if (device->path == nullptr) {
+                continue;
+            }
+
+            const auto normalized_path = lowercase(std::string(device->path));
+            all_paths.insert(normalized_path);
+            // A Move exposes multiple HID collections. Track collection 1
+            // and verify that its companion collection is also present below.
+            if (normalized_path.find("&col01#") == std::string::npos) {
+                continue;
+            }
+
+            candidates.push_back({
+                device->path,
+                device->serial_number == nullptr ? L"" : device->serial_number,
+                product_id,
+            });
+        }
+        hid_free_enumeration(devices);
+    }
+
+    MoveDevices result;
+    for (const auto &candidate : candidates) {
+        const auto normalized_path = lowercase(candidate.path);
+        auto address_path = normalized_path;
+        if (!replace_once(address_path, "&col01#", "&col02#") ||
+                !replace_once(address_path, "&0000#", "&0001#") ||
+                all_paths.count(address_path) == 0) {
+            // psmove_connect_internal() needs both collections on Windows.
+            continue;
+        }
+
+        result.emplace(normalized_path, MoveDevice{
+            candidate.path,
+            candidate.serial,
+            candidate.product_id,
+            // Windows exposes the controller serial over Bluetooth, while
+            // the USB interface has no usable serial.
+            candidate.serial.size() > 1
+                    ? EVENT_DEVICE_TYPE_BLUETOOTH
+                    : EVENT_DEVICE_TYPE_USB,
+        });
+    }
+    return result;
+}
+
+} // namespace
+
+
+struct _moved_monitor {
+    moved_event_callback event_callback;
+    void *event_callback_user_data;
+    std::atomic<bool> rescan_requested;
+    ULONGLONG next_rescan;
+    MoveDevices known_devices;
+
+    HMODULE cfgmgr32;
+    HCMNOTIFICATION notification;
+    CMUnregisterNotification unregister_notification;
+};
+
+
+static DWORD CALLBACK
+on_device_notification(HCMNOTIFICATION, PVOID context,
+        CM_NOTIFY_ACTION action, PCM_NOTIFY_EVENT_DATA event_data, DWORD)
+{
+    auto monitor = static_cast<moved_monitor *>(context);
+    if (monitor == nullptr || event_data == nullptr ||
+            event_data->FilterType != CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE) {
+        return ERROR_SUCCESS;
+    }
+
+    if ((action == CM_NOTIFY_ACTION_DEVICEINTERFACEARRIVAL ||
+            action == CM_NOTIFY_ACTION_DEVICEINTERFACEREMOVAL) &&
+            is_move_interface_path(event_data->u.DeviceInterface.SymbolicLink)) {
+        monitor->rescan_requested.store(true);
+    }
+    return ERROR_SUCCESS;
+}
+
+
+moved_monitor *
+moved_monitor_new(moved_event_callback callback, void *user_data)
+{
+    auto monitor = new moved_monitor();
+    monitor->event_callback = callback;
+    monitor->event_callback_user_data = user_data;
+    monitor->rescan_requested.store(true);
+    monitor->next_rescan = GetTickCount64();
+    // Load notifications dynamically so monitoring still works through the
+    // periodic rescan when the API is unavailable.
+    monitor->cfgmgr32 = LoadLibraryW(L"CfgMgr32.dll");
+    monitor->notification = nullptr;
+    monitor->unregister_notification = nullptr;
+
+    if (monitor->cfgmgr32 != nullptr) {
+        auto register_notification = reinterpret_cast<CMRegisterNotification>(
+                GetProcAddress(monitor->cfgmgr32, "CM_Register_Notification"));
+        monitor->unregister_notification = reinterpret_cast<CMUnregisterNotification>(
+                GetProcAddress(monitor->cfgmgr32, "CM_Unregister_Notification"));
+
+        if (register_notification != nullptr &&
+                monitor->unregister_notification != nullptr) {
+            CM_NOTIFY_FILTER filter = {};
+            filter.cbSize = sizeof(filter);
+            filter.Flags = CM_NOTIFY_FILTER_FLAG_ALL_INTERFACE_CLASSES;
+            filter.FilterType = CM_NOTIFY_FILTER_TYPE_DEVICEINTERFACE;
+            const auto result = register_notification(
+                    &filter, monitor, on_device_notification, &monitor->notification);
+            if (result != CR_SUCCESS) {
+                monitor->notification = nullptr;
+                PSMOVE_WARNING("Could not register for Windows device notifications (0x%lx)",
+                        static_cast<unsigned long>(result));
+            }
+        }
+    }
+
+    return monitor;
+}
+
+
+int
+moved_monitor_get_fd(moved_monitor *)
+{
+    // Windows notifications arrive through a callback instead of a pollable fd.
+    return -1;
+}
+
+
+void
+moved_monitor_poll(moved_monitor *monitor)
+{
+    psmove_return_if_fail(monitor != nullptr);
+
+    const auto now = GetTickCount64();
+    if (now >= monitor->next_rescan) {
+        monitor->rescan_requested.store(true);
+        monitor->next_rescan = now + RESCAN_INTERVAL_MS;
+    }
+    if (!monitor->rescan_requested.exchange(false)) {
+        return;
+    }
+
+    auto current_devices = enumerate_move_devices();
+
+    for (const auto &known : monitor->known_devices) {
+        if (current_devices.count(known.first) == 0) {
+            monitor->event_callback(
+                    EVENT_DEVICE_REMOVED,
+                    known.second.device_type,
+                    known.second.path.c_str(),
+                    nullptr,
+                    0,
+                    monitor->event_callback_user_data);
+        }
+    }
+
+    for (const auto &current : current_devices) {
+        if (monitor->known_devices.count(current.first) == 0) {
+            monitor->event_callback(
+                    EVENT_DEVICE_ADDED,
+                    current.second.device_type,
+                    current.second.path.c_str(),
+                    current.second.serial.empty() ? nullptr : current.second.serial.c_str(),
+                    current.second.product_id,
+                    monitor->event_callback_user_data);
+        }
+    }
+
+    monitor->known_devices = std::move(current_devices);
+}
+
+
+void
+moved_monitor_free(moved_monitor *monitor)
+{
+    psmove_return_if_fail(monitor != nullptr);
+
+    if (monitor->notification != nullptr &&
+            monitor->unregister_notification != nullptr) {
+        monitor->unregister_notification(monitor->notification);
+    }
+    if (monitor->cfgmgr32 != nullptr) {
+        FreeLibrary(monitor->cfgmgr32);
+    }
+    delete monitor;
+}

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -81,6 +81,19 @@ struct PSMoveAPI {
 PSMoveAPI *
 g_psmove_api = nullptr;
 
+bool
+device_paths_equal(const char *left, const char *right)
+{
+    if (left == nullptr || right == nullptr) {
+        return left == right;
+    }
+#ifdef _WIN32
+    return _stricmp(left, right) == 0;
+#else
+    return strcmp(left, right) == 0;
+#endif
+}
+
 }; // end anonymous namespace
 
 ControllerGlue::ControllerGlue(int index, const std::string &serial)
@@ -176,16 +189,12 @@ PSMoveAPI::PSMoveAPI(EventReceiver *receiver, void *user_data)
         controllers.emplace_back(c);
     }
 
-#ifndef _WIN32
     monitor = moved_monitor_new(PSMoveAPI::on_monitor_event, this);
-#endif
 }
 
 PSMoveAPI::~PSMoveAPI()
 {
-#ifndef _WIN32
     moved_monitor_free(monitor);
-#endif
 
     for (auto &c: controllers) {
         if (c->api_connected) {
@@ -204,10 +213,11 @@ PSMoveAPI::~PSMoveAPI()
 void
 PSMoveAPI::update()
 {
-#ifndef _WIN32
     if (moved_monitor_get_fd(monitor) == -1) {
         moved_monitor_poll(monitor);
-    } else {
+    }
+#ifndef _WIN32
+    else {
         struct pollfd pfd;
         pfd.fd = moved_monitor_get_fd(monitor);
         pfd.events = POLLIN;
@@ -301,8 +311,8 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
                        device_type, path, serial);
 
                 for (auto &c: self->controllers) {
-                    if ((c->move_bluetooth != nullptr && strcmp(_psmove_get_device_path(c->move_bluetooth), path) == 0) ||
-                            (c->move_usb != nullptr && strcmp(_psmove_get_device_path(c->move_usb), path) == 0)) {
+                    if ((c->move_bluetooth != nullptr && device_paths_equal(_psmove_get_device_path(c->move_bluetooth), path)) ||
+                            (c->move_usb != nullptr && device_paths_equal(_psmove_get_device_path(c->move_usb), path))) {
                         PSMOVE_WARNING("This controller is already active!");
                         return;
                     }
@@ -343,7 +353,7 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
                 for (auto &c: self->controllers) {
                     if (c->move_bluetooth != nullptr) {
                         const char *devpath = _psmove_get_device_path(c->move_bluetooth);
-                        if (devpath != nullptr && strcmp(devpath, path) == 0) {
+                        if (device_paths_equal(devpath, path)) {
                             psmove_disconnect(c->move_bluetooth), c->move_bluetooth = nullptr;
                             found = true;
                             break;
@@ -352,7 +362,7 @@ PSMoveAPI::on_monitor_event(enum MonitorEvent event, enum MonitorEventDeviceType
 
                     if (c->move_usb != nullptr) {
                         const char *devpath = _psmove_get_device_path(c->move_usb);
-                        if (devpath != nullptr && strcmp(devpath, path) == 0) {
+                        if (device_paths_equal(devpath, path)) {
                             psmove_disconnect(c->move_usb), c->move_usb = nullptr;
                             found = true;
                             break;

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -31,6 +31,12 @@ IF(PSMOVE_USE_PS3EYE_DRIVER)
         ${ROOT_DIR}/external/PS3EYEDriver/src/ps3eye.cpp
         ${ROOT_DIR}/external/PS3EYEDriver/src/ps3eye_capi.cpp)
 
+    if(MSVC)
+        # PS3EYEDriver uses timeval, which newer libusb headers no longer provide.
+        set_source_files_properties(${PS3_EYE_SRC}
+            PROPERTIES COMPILE_OPTIONS "/FIwinsock2.h")
+    endif()
+
     set(PS3_EYE_HEADER)
     list(APPEND PS3_EYE_HEADER
         ${ROOT_DIR}/external/PS3EYEDriver/src/ps3eye.h

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -106,7 +106,17 @@ on_monitor_update_pair(enum MonitorEvent event,
 
 int run_daemon()
 {
-#if defined(__linux) || defined(__APPLE__)
+#if defined(_WIN32)
+    moved_monitor *monitor = moved_monitor_new(on_monitor_update_pair, NULL);
+
+    while (1) {
+        moved_monitor_wait(monitor);
+        moved_monitor_poll(monitor);
+    }
+    moved_monitor_free(monitor);
+#elif defined(__linux) || defined(__APPLE__)
+    // TODO: Use a blocking monitor wait here after runtime testing it on
+    // Linux and macOS.
     moved_monitor *monitor = moved_monitor_new(on_monitor_update_pair, NULL);
     int monitor_fd = moved_monitor_get_fd(monitor);
     struct pollfd pfd;


### PR DESCRIPTION
Dynamic controller monitoring was added for Linux and macOS in previous commits. Windows did not have a `moved_monitor` implementation, so this functionality was disabled. This PR adds a Windows monitor using device notifications and periodic HID rescans, and fixes some issues with the Windows CI builds.

## Implementation

- Adds `moved_monitor_windows.cpp`
- Registers for Windows device-interface notifications through `CfgMgr32`
- Uses notifications to request an immediate HID rescan
- Performs periodic rescans as a fallback when notifications are unavailable or missed
- Detects both ZCM1 and ZCM2 controllers
- Handles the multiple HID collections exposed for each controller on Windows
- Uses case-insensitive device-path comparisons on Windows
- Enables monitor construction, polling, and cleanup in `PSMoveAPI` on Windows
- Pins Windows CI to `windows-2022`, the build currently targets Visual Studio 2022, and breaks with `windows-latest` which pulls in Visual Studio 2026
- Restores the PS3Eye MSVC build by including `winsock2.h`; newer libusb headers no longer supply the `timeval` definition that PS3EYEDriver relied on

The monitor reports controller additions and removals through the same `moved_monitor` interface already used on Linux and macOS.

## Testing

- Built successfully with Visual Studio 2022 x64 in Debug and Release
- Tested USB controller connection and pairing while the API was running
- Tested Bluetooth connection, removal, and reconnection without restarting the application
- Tested with multiple ZCM1 and ZCM2 controllers
- Tested through JoustMania's new Python ctypes integration on Windows 11