### PR TITLE
Unified moved_monitor_wait() for moved

### DIFF
--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -144,9 +144,9 @@ main(int argc, char *argv[])
         moved.handle_connection(NULL, NULL);
     }
 
-#if defined(__linux) || defined(__APPLE__)
     moved_monitor *monitor = moved_monitor_new(on_monitor_update_moved, &moved);
 
+#if defined(__linux) || defined(__APPLE__)
     struct pollfd pfd[2];
 
     pfd[0].fd = moved.get_socket();
@@ -169,7 +169,6 @@ main(int argc, char *argv[])
         moved.write_reports();
     }
 
-    moved_monitor_free(monitor);
 #else
     while (true) {
         moved.handle_request();
@@ -179,6 +178,8 @@ main(int argc, char *argv[])
         moved.write_reports();
     }
 #endif
+
+    moved_monitor_free(monitor);
 
     return 0;
 }

--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -43,6 +43,12 @@
 
 #include "psmove.h"
 
+#if defined(__APPLE__)
+#  include <sys/poll.h>
+#elif defined(__linux)
+#  include <poll.h>
+#endif
+
 #include <vector>
 
 struct move_daemon;
@@ -167,6 +173,9 @@ main(int argc, char *argv[])
 #else
     while (true) {
         moved.handle_request();
+        if (moved_monitor_wait(monitor, false)) {
+            moved_monitor_poll(monitor);
+        }
         moved.write_reports();
     }
 #endif

--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -158,6 +158,8 @@ main(int argc, char *argv[])
     pfd[0].fd = moved.get_socket();
     pfd[0].events = POLLIN;
 
+    // FIXME: On macOS, moved_monitor_get_fd() always returns -1,
+    // so the file descriptor cannot be polled.
     pfd[1].fd = moved_monitor_get_fd(monitor);
     pfd[1].events = POLLIN;
 
@@ -177,6 +179,12 @@ main(int argc, char *argv[])
 
 #else
     while (true) {
+        // In this fallback case (currently used on Windows), the
+        // moved.handle_request() function blocks in recvfrom(),
+        // so any monitor events might only be visible to clients
+        // once they send UDP requests. In the future, using
+        // select() from WinSock2 might be an option (or using
+        // threads and blocking I/O).
         moved.handle_request();
         if (moved_monitor_wait(monitor, false)) {
             moved_monitor_poll(monitor);

--- a/src/daemon/moved_monitor.h
+++ b/src/daemon/moved_monitor.h
@@ -37,6 +37,7 @@ extern "C" {
 #endif
 
 #include <wchar.h>
+#include <stdbool.h>
 
 enum MonitorEvent {
     EVENT_DEVICE_ADDED,
@@ -59,13 +60,18 @@ typedef struct _moved_monitor moved_monitor;
 ADDAPI moved_monitor *
 ADDCALL moved_monitor_new(moved_event_callback callback, void *user_data);
 
-#ifdef _WIN32
-// Block until Windows signals a device change or the fallback rescan is due.
-// Call moved_monitor_poll() after this returns to process any controller
-// additions or removals.
-ADDAPI void
-ADDCALL moved_monitor_wait(moved_monitor *monitor);
-#endif
+// If blocking is true:
+// Block until the OS signals a device change (or in some cases, a fallback
+// mechanism is used, e.g. interval-based polling), and return true.
+//
+// If blocking is false:
+// Will immediately return true if there are outstanding device changes,
+// or immediately return false otherwise.
+//
+// Call moved_monitor_poll() after this returns true to process any
+// controller additions or removals.
+ADDAPI bool
+ADDCALL moved_monitor_wait(moved_monitor *monitor, bool blocking);
 
 ADDAPI void
 ADDCALL moved_monitor_poll(moved_monitor *monitor);

--- a/src/daemon/moved_monitor_linux.c
+++ b/src/daemon/moved_monitor_linux.c
@@ -34,6 +34,8 @@
 
 #include <libudev.h>
 #include <linux/input.h>
+#include <linux/limits.h>
+#include <poll.h>
 
 #include "moved_monitor.h"
 
@@ -213,6 +215,21 @@ moved_monitor_poll(moved_monitor *monitor)
         _moved_monitor_handle_device(monitor, device);
         udev_device_unref(device);
     }
+}
+
+bool
+moved_monitor_wait(moved_monitor *monitor, bool blocking)
+{
+    psmove_return_val_if_fail(monitor != NULL, false);
+
+    int monitor_fd = moved_monitor_get_fd(monitor);
+
+    struct pollfd pfd;
+
+    pfd.fd = monitor_fd;
+    pfd.events = POLLIN;
+
+    return (poll(&pfd, 1, blocking ? -1 : 0) > 0);
 }
 
 void

--- a/src/daemon/moved_monitor_osx.mm
+++ b/src/daemon/moved_monitor_osx.mm
@@ -41,6 +41,10 @@
 #import <IOKit/hid/IOHIDManager.h>
 #import <CoreFoundation/CoreFoundation.h>
 
+#include <sys/syslimits.h>
+#include <sys/stat.h>
+#include <sys/poll.h>
+
 // Convenience functions copied from hidapi
 #include "moved_monitor_osx_hidapi.mm"
 
@@ -158,6 +162,21 @@ moved_monitor_poll(moved_monitor *monitor)
     psmove_return_if_fail(monitor != NULL);
 
     monitor->pump_loop();
+}
+
+bool
+moved_monitor_wait(moved_monitor *monitor, bool blocking)
+{
+    psmove_return_val_if_fail(monitor != nullptr, false);
+
+    int monitor_fd = moved_monitor_get_fd(monitor);
+
+    struct pollfd pfd;
+
+    pfd.fd = monitor_fd;
+    pfd.events = POLLIN;
+
+    return (poll(&pfd, 1, blocking ? -1 : 0) > 0);
 }
 
 void

--- a/src/daemon/moved_monitor_osx.mm
+++ b/src/daemon/moved_monitor_osx.mm
@@ -43,7 +43,6 @@
 
 #include <sys/syslimits.h>
 #include <sys/stat.h>
-#include <sys/poll.h>
 
 // Convenience functions copied from hidapi
 #include "moved_monitor_osx_hidapi.mm"
@@ -93,6 +92,10 @@ struct _moved_monitor {
                            event.pid, event_callback_user_data);
             events.pop();
         }
+    }
+
+    bool has_events() const {
+        return !events.empty();
     }
 
 private:
@@ -169,14 +172,27 @@ moved_monitor_wait(moved_monitor *monitor, bool blocking)
 {
     psmove_return_val_if_fail(monitor != nullptr, false);
 
-    int monitor_fd = moved_monitor_get_fd(monitor);
+    /* Blocking wait for events */
+    while (blocking && !monitor->has_events()) {
+        switch (CFRunLoopRunInMode(kCFRunLoopDefaultMode, 60.0, TRUE)) {
+            case kCFRunLoopRunFinished:
+            case kCFRunLoopRunStopped:
+                return false;
+            case kCFRunLoopRunTimedOut:
+                /* Timeout hit, try again */
+                break;
+            case kCFRunLoopRunHandledSource:
+                /* One source was handled, potentially events */
+                break;
+        }
+    }
 
-    struct pollfd pfd;
+    if (!monitor->has_events()) {
+        /* Poll once, ignore result, as we peek at has_events() below */
+        (void)CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, TRUE);
+    }
 
-    pfd.fd = monitor_fd;
-    pfd.events = POLLIN;
-
-    return (poll(&pfd, 1, blocking ? -1 : 0) > 0);
+    return monitor->has_events();
 }
 
 void

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -308,9 +308,6 @@ moved_monitor_wait(moved_monitor *monitor, bool blocking)
 {
     psmove_return_val_if_fail(monitor != nullptr, false);
 
-    // TODO: This function only returns "true" for now, causing a
-    // rescan all the time. Eventually implement returning "false".
-
     const auto now = GetTickCount64();
     if (monitor->rescan_requested.load() || now >= monitor->next_rescan) {
         return true;

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -338,7 +338,7 @@ moved_monitor_wait(moved_monitor *monitor, bool blocking)
                 static_cast<unsigned long>(GetLastError()));
     }
 
-    return true;
+    return (result == WAIT_OBJECT_0);
 }
 
 

--- a/src/daemon/moved_monitor_windows.cpp
+++ b/src/daemon/moved_monitor_windows.cpp
@@ -303,14 +303,17 @@ moved_monitor_get_fd(moved_monitor *)
     return -1;
 }
 
-void
-moved_monitor_wait(moved_monitor *monitor)
+bool
+moved_monitor_wait(moved_monitor *monitor, bool blocking)
 {
-    psmove_return_if_fail(monitor != nullptr);
+    psmove_return_val_if_fail(monitor != nullptr, false);
+
+    // TODO: This function only returns "true" for now, causing a
+    // rescan all the time. Eventually implement returning "false".
 
     const auto now = GetTickCount64();
     if (monitor->rescan_requested.load() || now >= monitor->next_rescan) {
-        return;
+        return true;
     }
 
     const auto remaining = monitor->next_rescan - now;
@@ -319,18 +322,23 @@ moved_monitor_wait(moved_monitor *monitor)
             : static_cast<DWORD>(remaining);
 
     if (monitor->device_event == nullptr) {
-        Sleep(timeout);
-        return;
+        if (blocking) {
+            // Simulated blocking based on timeout
+            Sleep(timeout);
+        }
+        return true;
     }
 
     // The notification callback signals the event immediately. The timeout
     // preserves periodic rescanning if Windows misses a notification.
-    const auto result = WaitForSingleObject(monitor->device_event, timeout);
+    const auto result = WaitForSingleObject(monitor->device_event, blocking ? timeout : 0);
     if (result == WAIT_FAILED) {
         PSMOVE_WARNING(
                 "Could not wait for Windows device notification (%lu)",
                 static_cast<unsigned long>(GetLastError()));
     }
+
+    return true;
 }
 
 

--- a/src/psmove_port.h
+++ b/src/psmove_port.h
@@ -35,13 +35,11 @@
 #  include <unistd.h>
 #  include <sys/syslimits.h>
 #  include <sys/stat.h>
-#  include <sys/poll.h>
 #endif
 
 #ifdef __linux
 #  include <unistd.h>
 #  include <linux/limits.h>
-#  include <poll.h>
 #endif
 
 #ifdef _WIN32

--- a/src/psmoveapi.cpp
+++ b/src/psmoveapi.cpp
@@ -213,19 +213,9 @@ PSMoveAPI::~PSMoveAPI()
 void
 PSMoveAPI::update()
 {
-    if (moved_monitor_get_fd(monitor) == -1) {
+    if (moved_monitor_wait(monitor, false)) {
         moved_monitor_poll(monitor);
     }
-#ifndef _WIN32
-    else {
-        struct pollfd pfd;
-        pfd.fd = moved_monitor_get_fd(monitor);
-        pfd.events = POLLIN;
-        while (poll(&pfd, 1, 0) > 0) {
-            moved_monitor_poll(monitor);
-        }
-    }
-#endif
 
     for (auto &c: controllers) {
         c->update_connection_flags();

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -106,37 +106,15 @@ on_monitor_update_pair(enum MonitorEvent event,
 
 int run_daemon()
 {
-#if defined(_WIN32)
     moved_monitor *monitor = moved_monitor_new(on_monitor_update_pair, NULL);
 
-    while (1) {
-        moved_monitor_wait(monitor);
-        moved_monitor_poll(monitor);
-    }
-    moved_monitor_free(monitor);
-#elif defined(__linux) || defined(__APPLE__)
-    // TODO: Use a blocking monitor wait here after runtime testing it on
-    // Linux and macOS.
-    moved_monitor *monitor = moved_monitor_new(on_monitor_update_pair, NULL);
-    int monitor_fd = moved_monitor_get_fd(monitor);
-    struct pollfd pfd;
-
-    pfd.fd = monitor_fd;
-    pfd.events = POLLIN;
-
-    while (1) {
-        if (poll(&pfd, 1, 0) > 0) {
+    while (true) {
+        if (moved_monitor_wait(monitor, true)) {
             moved_monitor_poll(monitor);
         }
     }
 
     moved_monitor_free(monitor);
-#else
-    for(;;) {
-        psmove_port_sleep_ms(5000);
-        pair(NULL);
-    }
-#endif
 
     return 0;
 }


### PR DESCRIPTION
A cleanup on top of #519 for unifying monitor waiting between macOS, Linux and Windows.

Tested:

- Building on Linux locally
- (+ CI will test building on other OSes)

Not tested:

- Building on macOS
- `psmove pair -d` on any OS
- `psmove daemon` on any OS

cc @adangert if you could check if this works for you, that'd be great :)