### PR TITLE
CLI: Command-line help message; fix host lookup bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ starting after version 4.0.12, but historic entries might not.
 - Replaced `enum PSMove_Bool`, `PSMove_True` and `PSMove_False` with C99 (`stdbool.h`) / C++ `bool`, `true`, `false`
 - Increased maximum number of tracked controllers from 5 to 7
 - Blinking calibration now takes the new hue-based quality criteria into account, does per-controller dimming
+- For the CLI (`psmove`), every subcommand now accepts `-h` / `--help` and `psmove help <subcommand>` also
+  works for retrieving usage information for subcommands
 
 ### Fixed
 

--- a/src/daemon/moved.cpp
+++ b/src/daemon/moved.cpp
@@ -122,6 +122,12 @@ on_monitor_update_moved(enum MonitorEvent event,
 int
 main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     if (!psmove_port_check_pairing_permissions()) {
         printf("Warning: Connected devices won't be paired.\n");
     }

--- a/src/daemon/moved_client.cpp
+++ b/src/daemon/moved_client.cpp
@@ -209,8 +209,13 @@ moved_client_create(const char *hostname)
     {
         struct hostent *remoteHost = gethostbyname(hostname);
 
-        if (remoteHost->h_addrtype == AF_INET) 
+        if (remoteHost == NULL) {
+            PSMOVE_FATAL("Cannot resolve hostname: %s", hostname);
+        }
+
+        if (remoteHost->h_addrtype == AF_INET) {
             client->moved_addr.sin_addr.s_addr = *(u_long *)remoteHost->h_addr_list[0];
+        }
     }
 
     //assert(client->moved_addr.sin_addr.s_addr != INADDR_NONE);

--- a/src/utils/battery_check.cpp
+++ b/src/utils/battery_check.cpp
@@ -84,6 +84,12 @@ struct ColorHandler : public psmoveapi::Handler {
 int
 main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     ColorHandler handler;
 
     psmoveapi::PSMoveAPI api(&handler);

--- a/src/utils/distance_calibration.cpp
+++ b/src/utils/distance_calibration.cpp
@@ -60,8 +60,14 @@ save(IplImage *image, int distance)
 }
 
 int
-main(int arg, char** args)
+main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     measurement measurements[MEASUREMENTS];
     float distance = MEASUREMENTS_CM_START;
     int pos = 0;

--- a/src/utils/dump_calibration.c
+++ b/src/utils/dump_calibration.c
@@ -37,6 +37,12 @@
 int
 main(int argc, char* argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     PSMove *move;
     int i;
     int count;

--- a/src/utils/magnetometer_calibration.c
+++ b/src/utils/magnetometer_calibration.c
@@ -54,8 +54,14 @@ static bool is_move_stable_and_aligned_with_gravity(PSMove *move);
 
 //-- public methods ----
 int
-main(int arg, char** args)
+main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
 	if (!psmove_init(PSMOVE_CURRENT_VERSION)) {
 		fprintf(stderr, "PS Move API init failed (wrong version?)\n");
 		exit(1);

--- a/src/utils/psmove_auth_response.c
+++ b/src/utils/psmove_auth_response.c
@@ -38,6 +38,12 @@ void send_and_receive(PSMove *move, PSMove_Data_AuthChallenge *challenge)
 
 int main(int argc, char* argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     PSMove *move;
     int i;
 

--- a/src/utils/psmove_get_firmware_info.cpp
+++ b/src/utils/psmove_get_firmware_info.cpp
@@ -8,6 +8,12 @@
 int
 main(int argc, char* argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     int result = 0;
 
     int count = psmove_count_connected();

--- a/src/utils/psmovecli.cpp
+++ b/src/utils/psmovecli.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "psmoveapi.h"
+#include "psmove_format.h"
 
 typedef int (*subcommand_func_t)(int argc, char *argv[]);
 
@@ -125,6 +126,7 @@ usage(const char *progname, std::vector<SubCommand> &subcommands)
         }
     }
     printf("\n");
+    printf("Use %s help <cmd> to get help for subcommands.\n\n", progname);
 
     return 0;
 }
@@ -220,6 +222,12 @@ public:
 int
 list_main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     ListHandler handler;
     psmoveapi::PSMoveAPI api(&handler);
 
@@ -271,13 +279,29 @@ main(int argc, char *argv[])
     subcommands.emplace_back("camera-firmware", "Initialize PS4/PS5 camera by uploading its firmware via USB", ps4_camera_firmware_main);
 #endif /* PSMOVE_BUILD_TRACKER */
 
-    if (argc == 1 || strcmp(argv[1], "help") == 0) {
+    if (argc == 1 || (argc == 2 && strcmp(argv[1], "help") == 0)) {
         return usage(argv[0], subcommands);
+    } else if (argc == 3 && strcmp(argv[1], "help") == 0) {
+        // "psmove help <subcommand>" -> "psmove <subcommand> -h"
+        argv[1] = argv[2];
+        argv[2] = strdup("-h"); // We leak a little memory here
     }
 
     for (auto &cmd: subcommands) {
         if (cmd.cmd != nullptr && strcmp(cmd.cmd, argv[1]) == 0) {
-            return cmd.func(argc-1, argv+1);
+            // Here, we still have:
+            //  argv[0] == "psmove"
+            //  argv[1] == "subcommand"
+            // Make it so that the subcommand sees:
+            //  argv[0] == "psmove subcommand"
+            std::string progname = format("%s %s", argv[0], argv[1]);
+            char *old_argv1 = argv[1];
+            char *new_argv0 = strdup(progname.c_str());
+            argv[1] = new_argv0;
+            int res = cmd.func(argc-1, argv+1);
+            free(new_argv0);
+            argv[1] = old_argv1;
+            return res;
         }
     }
 

--- a/src/utils/psmovepair.c
+++ b/src/utils/psmovepair.c
@@ -148,7 +148,13 @@ int main(int argc, char* argv[])
     int daemon_mode = 0;
 
     if (argc > 1) {
-        if (strcmp(argv[1], "-d") == 0) {
+        if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
+            fprintf(stderr, "Usage: %s [-d|<host-btaddr>]\n", argv[0]);
+            fprintf(stderr, "Parameters:\n");
+            fprintf(stderr, "  -d .............. Keep running and pair on connect (daemon mode)\n");
+            fprintf(stderr, "  <host-btaddr> ... Custom host BT address to pair to\n");
+            fprintf(stderr, "                    (if not set, use the host this tool is running on)\n");
+        } else if (strcmp(argv[1], "-d") == 0) {
             daemon_mode = 1;
         } else {
             if (_psmove_btaddr_from_string(argv[1], NULL)) {

--- a/src/utils/psmoveregister.c
+++ b/src/utils/psmoveregister.c
@@ -43,12 +43,19 @@ static const char *OPT_PS4 = "--ps4";
 static void
 psmoveregister_usage(const char *progname)
 {
-    fprintf(stderr, "Usage: %s [%s] bluetooth-address\n", progname, OPT_PS4);
+    fprintf(stderr, "Usage: %s [%s] <bluetooth-address>\n", progname, OPT_PS4);
+    fprintf(stderr, " %s ................. Register a PS4 Move controller (default: PS3 Move)\n", OPT_PS4);
+    fprintf(stderr, " <bluetooth-address> ... Bluetooth address of the controller to register\n");
 }
 
 int
 main(int argc, char *argv[])
 {
+    if (argc == 1 || (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))) {
+        psmoveregister_usage(argv[0]);
+        return 1;
+    }
+
     if (!psmove_port_check_pairing_permissions()) {
         return 1;
     }

--- a/src/utils/psmoveremotepair.cpp
+++ b/src/utils/psmoveremotepair.cpp
@@ -42,8 +42,8 @@
 
 int main(int argc, char* argv[])
 {
-    if (argc != 2) {
-        printf("Usage: %s [hostname]\n", argv[0]);
+    if (argc != 2 || (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))) {
+        fprintf(stderr, "Usage: %s [hostname]\n", argv[0]);
         return 1;
     }
 

--- a/src/utils/sixpair.c
+++ b/src/utils/sixpair.c
@@ -123,6 +123,12 @@ void process_device(int argc, char **argv, struct usb_device *dev,
 
 int main(int argc, char *argv[]) {  
 
+  if (argc != 1) {
+    fprintf(stderr, "Usage: %s\n", argv[0]);
+    fprintf(stderr, "This tool does not take any arguments.\n");
+    return 1;
+  }
+
   usb_init();
   if ( usb_find_busses() < 0 ) fatal("usb_find_busses");
   if ( usb_find_devices() < 0 ) fatal("usb_find_devices");

--- a/src/utils/test_extension.c
+++ b/src/utils/test_extension.c
@@ -132,6 +132,12 @@ void handle_racing_wheel(PSMove *move, PSMove_Ext_Data *data, unsigned int move_
 
 int main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     if (!psmove_init(PSMOVE_CURRENT_VERSION)) {
         fprintf(stderr, "PS Move API init failed (wrong version?)\n");
         exit(1);

--- a/src/utils/test_led_pwm_frequency.c
+++ b/src/utils/test_led_pwm_frequency.c
@@ -50,6 +50,12 @@ unsigned long freqs[NUM_FREQS] = { 800, 2500, 5000, 10000, 153600, 230400, 30720
 
 int main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     if (!psmove_init(PSMOVE_CURRENT_VERSION)) {
         fprintf(stderr, "PS Move API init failed (wrong version?)\n");
         exit(1);

--- a/src/utils/test_responsiveness.c
+++ b/src/utils/test_responsiveness.c
@@ -52,6 +52,12 @@ int convert_accel_to_col(int accel)
 
 int main(int argc, char* argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     if (!psmove_init(PSMOVE_CURRENT_VERSION)) {
         fprintf(stderr, "PS Move API init failed (wrong version?)\n");
         exit(1);

--- a/src/utils/test_tracker.cpp
+++ b/src/utils/test_tracker.cpp
@@ -267,8 +267,14 @@ test_tracker_on_mouse(int event, int x, int y, int flags, void *userdata)
 }
 
 int
-main(int arg, char *args[])
+main(int argc, char *argv[])
 {
+    if (argc != 1) {
+        fprintf(stderr, "Usage: %s\n", argv[0]);
+        fprintf(stderr, "This tool does not take any arguments.\n");
+        return 1;
+    }
+
     int count = psmove_count_connected();
 
     PSMOVE_INFO("%d controllers connected", count);

--- a/src/utils/tracker_camera_calibration.cpp
+++ b/src/utils/tracker_camera_calibration.cpp
@@ -69,8 +69,8 @@ capture_frame(PSMoveTracker *tracker)
 int
 camera_calibration_main(int argc, char *argv[])
 {
-    if (argc == 1) {
-        PSMOVE_FATAL("Usage: %s filename.xml", argv[0]);
+    if (argc == 1 || (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))) {
+        fprintf(stderr, "Usage: %s <filename.xml>\n", argv[0]);
         return 1;
     }
 
@@ -207,8 +207,8 @@ camera_calibration_main(int argc, char *argv[])
 int
 verify_camera_calibration_main(int argc, char *argv[])
 {
-    if (argc == 1) {
-        PSMOVE_FATAL("Usage: %s filename.xml", argv[0]);
+    if (argc == 1 || (argc == 2 && (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0))) {
+        fprintf(stderr, "Usage: %s <filename.xml>\n", argv[0]);
         return 1;
     }
 


### PR DESCRIPTION
Allow for `psmove help <subcommand>` and make every subcommand react sensibly to `-h` / `--help`.