### PR TITLE
moved protocol: Fix struct alignment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ starting after version 4.0.12, but historic entries might not.
 - Fix macOS version detection for macOS 11 and newer (fixes #456)
 - `examples/labs/`: Fix building of Qt examples by migrating to Qt 5
 - Fixed the kernel center of CV-related image filters (was off-center before)
+- Fix struct alignment issues on macOS/ARM64
 
 ### Removed
 

--- a/src/daemon/psmove_moved_protocol.h
+++ b/src/daemon/psmove_moved_protocol.h
@@ -59,7 +59,7 @@ struct PACKED PSMoveMovedProtocolHeader {
     uint16_t controller_id;
 };
 
-union PACKED PSMoveMovedRequest {
+typedef union PACKED PSMoveMovedRequest {
     struct {
         struct PSMoveMovedProtocolHeader header;
 
@@ -77,9 +77,9 @@ union PACKED PSMoveMovedRequest {
     };
 
     uint8_t bytes[16];
-};
+} PSMoveMovedRequest;
 
-union PACKED PSMoveMovedResponse {
+typedef union PACKED PSMoveMovedResponse {
     struct {
         struct PSMoveMovedProtocolHeader header;
 
@@ -106,12 +106,13 @@ union PACKED PSMoveMovedResponse {
                 uint8_t btaddr[6];
             } get_host_btaddr;
         };
-
-        uint8_t _padding[3];
     };
 
     uint8_t bytes[64];
-};
+} PSMoveMovedResponse;
+
+static_assert(sizeof(PSMoveMovedRequest) == 16, "");
+static_assert(sizeof(PSMoveMovedResponse) == 64, "");
 
 #ifdef _WIN32
 #pragma pack(pop)


### PR DESCRIPTION
When using ARM64 macOS as client for AMD64 Windows, the structs over the wire had different sizes/alignment/padding.