### PR TITLE
Fix hang at end of camera firmware upload

### DIFF
--- a/src/utils/ps4_camera_firmware.cpp
+++ b/src/utils/ps4_camera_firmware.cpp
@@ -256,7 +256,12 @@ Optional parameters:
 
     libusb_free_device_list(devs, 1);
 
-    libusb_exit(usb_context);
+    // We would need to properly cleanup the libusb context, but since
+    // the device we keep opened goes away as part of the firmware upload,
+    // there are cases where libusb just hangs. Since ps4_camera_firmware_main()
+    // is only called from the CLI, and the process exits after returning from
+    // here, let's skip the cleanup and let the operating system take care of it.
+    //libusb_exit(usb_context);
 
     return 0;
 }


### PR DESCRIPTION
In my tests, `libusb_exit()` sometimes hung after firmware upload (because the device got disconnected right after we uploaded the firmware, and we didn't call `libusb_close()` on the device). As the process exits immediately afterwards, let's skip the cleanup and let the OS take care of it.